### PR TITLE
feat: add confluent-cloud-cdc-tableflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repository includes the following skills:
 |--------------------------------|-------------|
 | **kafka-streams-programming**  | Architect, build, and debug Kafka Streams applications that run as a library inside your JVM with no separate cluster required. Handles topology design, pattern selection (joins, windows, aggregations), code generation for complete projects with proper Schema Registry integration, and troubleshooting production issues like rebalancing loops, state store problems, and performance tuning. |
 | **developing-kafka-python-client**  | Scaffold a Python Kafka producer/consumer project using confluent-kafka-python with Schema Registry serialization (Avro, JSON Schema, or Protobuf). Supports async (AIOProducer) and synchronous (Producer) modes, Confluent Cloud, and local Docker. |
+| **confluent-cloud-cdc-tableflow** | Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. Supports SQL Server, MySQL, PostgreSQL, Oracle, and DynamoDB to Iceberg or Delta Lake tables. |
 
 ## Repository layout
 

--- a/skills/confluent-cloud-cdc-tableflow/SKILL.md
+++ b/skills/confluent-cloud-cdc-tableflow/SKILL.md
@@ -1,0 +1,472 @@
+---
+name: confluent-cloud-cdc-tableflow
+description: |
+  Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill whenever users mention CDC, Debezium, Tableflow, streaming database changes, replication to data lakes, real-time data pipelines from databases, or want to stream changes from SQL Server, MySQL, PostgreSQL, Oracle, or DynamoDB to Iceberg or Delta Lake. Also trigger for phrases like "set up database replication", "stream database to data lake", "capture database changes", "sync database to Iceberg/Delta", or any mention of connecting databases to Confluent Cloud with Schema Registry.
+compatibility:
+  tools:
+    - Bash
+    - Read
+    - Write
+    - Edit
+    - mcp__confluent__* (Confluent MCP Server - preferred for all operations)
+---
+
+# Confluent Cloud CDC to Tableflow Pipeline
+
+Build production-ready Change Data Capture pipelines that stream database changes through Confluent Cloud to Iceberg or Delta Lake tables using Debezium, Flink, and Tableflow.
+
+## Overview
+
+This skill automates the setup of a complete CDC pipeline:
+
+**Database → Debezium CDC Connector → Kafka + Schema Registry → Flink (decode & transform) → Tableflow → Iceberg/Delta Tables**
+
+### Supported Databases (Fully-Managed Debezium Connectors Only)
+- Microsoft SQL Server CDC Source V2
+- MySQL CDC Source V2
+- PostgreSQL CDC Source V2
+- Oracle XStream CDC Source
+- DynamoDB CDC Source
+
+### Key Components
+1. **Debezium CDC Source Connector**: Captures database changes as events
+2. **Schema Registry**: Manages Avro/JSON/Protobuf schemas (default: JSON_SR)
+3. **Confluent Cloud Flink**: Decodes Debezium envelopes and transforms data
+4. **Tableflow**: Native Confluent Cloud feature that materializes Kafka topics as Iceberg or Delta tables
+
+### Important Clarifications
+- **Tableflow is NOT a connector.** It is a native topic-level feature enabled via the Tableflow API or Confluent Cloud UI.
+- **Confluent Cloud Flink auto-discovers CDC tables.** You do NOT need to manually create source tables — topics with Schema Registry schemas are automatically available as Flink tables.
+- **Managed connectors use `output.data.format`**, not `key.converter`/`value.converter` classes.
+
+## Workflow Phases
+
+### Phase 0: Tool Selection & MCP Server Validation (CRITICAL)
+
+**Default: Use Confluent MCP Server.** The MCP server is the preferred method for all Confluent Cloud operations. Only fall back to the Confluent CLI (`confluent` command) and REST APIs if the MCP server is not installed or unavailable.
+
+#### 0.1 Verify MCP Server Availability
+
+Check if the Confluent MCP tools are available. Look for tools prefixed with `mcp__confluent__`. Key tools needed:
+- `mcp__confluent__list-environments`
+- `mcp__confluent__list-clusters`
+- `mcp__confluent__create-connector` / `mcp__confluent__read-connector` / `mcp__confluent__delete-connector`
+- `mcp__confluent__create-flink-statement` / `mcp__confluent__read-flink-statement` / `mcp__confluent__list-flink-statements`
+- `mcp__confluent__create-tableflow-topic` / `mcp__confluent__list-tableflow-topics`
+- `mcp__confluent__list-schemas` / `mcp__confluent__list-topics` / `mcp__confluent__consume-messages`
+- `mcp__confluent__search-topics-by-name`
+
+**If MCP is not available**, fall back to the Confluent CLI (`confluent` command) and REST APIs for all operations. The CLI fallback should mirror the same workflow phases but use CLI commands instead of MCP tool calls.
+
+**CLI Fallback Examples:**
+```bash
+# Environment & cluster discovery
+confluent environment list
+confluent kafka cluster list --environment <env-id>
+
+# Connector operations
+confluent connect cluster create --config-file connector-config.json --cluster <cluster-id> --environment <env-id>
+confluent connect cluster describe <connector-id>
+confluent connect cluster list --cluster <cluster-id> --environment <env-id>
+
+# Flink operations
+confluent flink statement create <statement-name> --sql "<SQL>" --compute-pool <pool-id> --environment <env-id>
+confluent flink statement describe <statement-name> --environment <env-id>
+
+# Topic & schema operations
+confluent kafka topic list --cluster <cluster-id> --environment <env-id>
+confluent schema-registry subject list --environment <env-id>
+```
+
+#### 0.2 Read MCP Environment File for Defaults (CRITICAL)
+
+**Before asking the user for environment/cluster details, read the MCP server's `.env` file to extract defaults.** The `.env` file path is specified in the project's `.mcp.json` (look for the `-e` flag in the `args` array). If not found there, check `~/.config/claude/mcp.json` for an `envFile` field.
+
+Read the `.env` file and extract these defaults:
+
+| .env Variable | Purpose | Use As Default For |
+|---|---|---|
+| `KAFKA_ENV_ID` | Environment ID | `environmentId` in all MCP calls |
+| `KAFKA_CLUSTER_ID` | Kafka cluster ID | `clusterId` in all MCP calls |
+| `BOOTSTRAP_SERVERS` | Kafka bootstrap endpoint | MCP cluster targeting |
+| `KAFKA_API_KEY` / `KAFKA_API_SECRET` | Cluster-scoped Kafka API keys | Connector `kafka.api.key` / `kafka.api.secret` |
+| `FLINK_COMPUTE_POOL_ID` | Flink compute pool | `computePoolId` in Flink statements |
+| `FLINK_ENV_NAME` | Flink catalog name | `catalogName` in Flink statements |
+| `FLINK_DATABASE_NAME` | Flink database name | `databaseName` in Flink statements |
+| `FLINK_REST_ENDPOINT` | Flink API base URL | `baseUrl` for Flink MCP calls |
+| `FLINK_ORG_ID` | Organization ID | `organizationId` in Flink MCP calls |
+| `SCHEMA_REGISTRY_ENDPOINT` | Schema Registry URL | Verification only |
+
+**If the `.env` file contains these values**, present them to the user and ask for confirmation before proceeding. For example:
+
+> "I found the following targets in your MCP `.env` file:
+> - **Environment:** `env-0ypxv6`
+> - **Cluster:** `lkc-qo5k36` (bootstrap: `pkc-921jm.us-east-2.aws.confluent.cloud:9092`)
+> - **Flink Compute Pool:** `lfcp-3v39xw` (catalog: `erick_cdc_tableflow_test`, database: `cluster_0`)
+> - **Schema Registry:** `psrc-19262jq.us-east-2.aws.confluent.cloud`
+>
+> Should I use these for the pipeline, or would you like to target a different environment/cluster?"
+
+If the user confirms, use these values throughout the pipeline. If they want different targets, ask them to specify.
+
+**If the `.env` file is not found or missing key variables**, ask the user which environment and cluster to use, then fall back to discovering via `mcp__confluent__list-environments` and `mcp__confluent__list-clusters`.
+
+#### 0.3 Verify MCP Cluster Targeting
+
+The MCP server's `BOOTSTRAP_SERVERS` and `KAFKA_API_KEY` from the `.env` file determine which cluster it targets for Kafka operations (consume, list-topics, create-tableflow-topic).
+
+**Quick verification:**
+1. Run `mcp__confluent__list-topics` to confirm the MCP server is connected to the expected cluster
+2. Run `mcp__confluent__list-schemas` to verify Schema Registry is accessible
+
+Schema Registry is shared at the environment level across all clusters.
+
+### Phase 1: Discovery & Validation
+
+#### 1.1 Check Existing Setup
+
+Use MCP to check what already exists:
+
+```
+mcp__confluent__list-connectors(environmentId, clusterId)  →  Existing CDC connectors
+mcp__confluent__list-flink-statements(environmentId, computePoolId)  →  Existing Flink jobs
+mcp__confluent__list-tableflow-topics(environmentId, clusterId)  →  Existing Tableflow topics
+```
+
+Ask the user:
+- "Do you have any CDC connectors already running?"
+- "Do you have a Flink compute pool you'd like to use, or should I create one?"
+- "Is your database already configured for CDC?"
+
+#### 1.2 Gather Required Information
+
+**Database Configuration:**
+- Database type (SQL Server, MySQL, PostgreSQL, Oracle, or DynamoDB)
+- Connection details (hostname, port, database name)
+- Credentials (username, password)
+- Specific tables to capture (format: `schema.table`)
+
+**Kafka API Keys:**
+- The CDC connector needs Kafka API keys scoped to the target cluster
+- If the MCP `.env` file contains `KAFKA_API_KEY` and `KAFKA_API_SECRET`, use those as defaults
+- Only ask the user for Kafka API keys if they are not present in the `.env` file
+
+**Tableflow Destination:**
+- Target format: Iceberg or Delta Lake
+- Storage: Managed (recommended, Confluent manages S3) or BYOB (user's own S3 bucket, requires Provider Integration ID)
+
+**Naming Convention:**
+- Default: `cdc-pipeline-skill-{database-type}-{YYYYMMDD}`
+- Example: `cdc-pipeline-skill-postgres-20260323`
+
+#### 1.3 Validate Database Prerequisites
+
+Each database requires specific CDC setup. Read `references/database-prerequisites.md` for details:
+- PostgreSQL: WAL level = logical, replication slots, publication
+- MySQL: binlog format = ROW, GTID mode
+- SQL Server: CDC enabled on database and tables, SQL Server Agent running
+- Oracle: Archive log mode, supplemental logging, XStream
+- DynamoDB: Streams enabled with NEW_AND_OLD_IMAGES
+
+If the database isn't properly configured, guide the user through setup before proceeding.
+
+### Phase 2: Planning
+
+Generate the complete configuration plan and present it to the user for approval.
+
+#### 2.1 Connector Configuration
+
+Based on the database type, generate the connector configuration. See `references/connector-configs.md` for templates.
+
+**Required fields for ALL CDC V2 connectors:**
+- `connector.class`: The connector class (e.g., `PostgresCdcSourceV2`)
+- `topic.prefix`: **REQUIRED** — Controls topic naming. Topics will be named `{topic.prefix}.{schema}.{table}`
+- `kafka.api.key` / `kafka.api.secret`: Kafka API keys for the target cluster
+- `output.data.format`: `JSON_SR` (default, recommended — uses JSON serializer with schema ID in header, safer for downstream consumers)
+- `output.key.format`: `JSON_SR`
+- `snapshot.mode`: `initial` (snapshot + stream), `never` (stream only)
+- `tombstones.on.delete`: `true`
+- `tasks.max`: `1` (recommended for CDC)
+
+**Topic Naming Pattern:**
+`{topic.prefix}.{schema}.{table}`
+Example with `topic.prefix = "postgres-cdc"`: `postgres-cdc.public.customers`
+
+#### 2.2 Flink SQL Statements
+
+In Confluent Cloud Flink, the CDC source table is **auto-discovered** from the Kafka topic. You only need to:
+
+1. **Create a target table** (for plain JSON_SR output to Tableflow):
+```sql
+CREATE TABLE `target_customers` (
+  `id` INT NOT NULL,
+  `name` STRING,
+  `email` STRING,
+  `created_at` TIMESTAMP_LTZ(3),
+  PRIMARY KEY (`id`) NOT ENFORCED
+) WITH (
+  'changelog.mode' = 'upsert'
+);
+```
+
+2. **Create an INSERT statement** (continuous job to decode and transform):
+```sql
+INSERT INTO `target_customers`
+SELECT
+  `id`,
+  `name`,
+  `email`,
+  TO_TIMESTAMP_LTZ(`created_at` / 1000, 3)
+FROM `postgres-cdc.public.customers`;
+```
+
+**IMPORTANT Cloud Flink differences:**
+- Do NOT specify `'connector'`, `'value.format'`, `'properties.bootstrap.servers'`, or Schema Registry URLs in CREATE TABLE — Cloud Flink handles all of this automatically
+- Do NOT create source tables for CDC topics — they are auto-discovered
+- Do NOT reference `after.*` fields or filter by `op` — Flink interprets CDC changelog semantics natively
+- Use `TIMESTAMP_LTZ(3)` for Debezium timestamps, not `TIMESTAMP(3)`
+
+**Debezium Type Conversions:**
+| Debezium Type | Flink Source Type | Target Type | Conversion |
+|---|---|---|---|
+| `MicroTimestamp` | BIGINT (microseconds) | TIMESTAMP_LTZ(3) | `TO_TIMESTAMP_LTZ(col / 1000, 3)` |
+| `Timestamp` | BIGINT (milliseconds) | TIMESTAMP_LTZ(3) | `TO_TIMESTAMP_LTZ(col, 3)` |
+| `Date` | INT (days since epoch) | DATE | Direct or cast |
+| Numeric/String | Direct mapping | Same | No conversion needed |
+
+For detailed patterns, see `references/flink-sql-patterns.md`.
+
+#### 2.3 Tableflow Configuration
+
+Tableflow is a **native topic-level feature**, not a connector. It is enabled per-topic.
+
+**Storage Options:**
+- **Managed** (recommended): Confluent manages the S3 storage. No credentials needed.
+- **BYOB (Bring Your Own Bucket)**: User provides their S3 bucket. Requires a Provider Integration ID set up in Confluent Cloud (Settings → Provider Integrations).
+
+**Table Formats:** Iceberg (recommended) or Delta Lake
+
+#### 2.4 Present the Plan
+
+Show the user:
+1. Connector configuration (with sensitive fields masked)
+2. Flink compute pool to use
+3. Flink SQL statements (target table + INSERT)
+4. Tableflow config (storage type, format)
+5. Expected topic names
+
+Wait for explicit confirmation before proceeding.
+
+### Phase 3: Execution
+
+Execute step-by-step using MCP tools, checking status after each component.
+
+#### 3.1 Create CDC Source Connector
+
+**Using MCP:**
+```
+mcp__confluent__create-connector(
+  connectorName: "cdc-pipeline-skill-postgres-20260323-connector",
+  environmentId: "<env-id>",
+  clusterId: "<cluster-id>",
+  connectorConfig: {
+    "connector.class": "PostgresCdcSourceV2",
+    "topic.prefix": "postgres-cdc",
+    "database.hostname": "<host>",
+    "database.port": "5432",
+    "database.user": "<user>",
+    "database.password": "<password>",
+    "database.dbname": "<dbname>",
+    "table.include.list": "public.customers",
+    "kafka.api.key": "<KAFKA_API_KEY>",
+    "kafka.api.secret": "<KAFKA_API_SECRET>",
+    "output.data.format": "JSON_SR",
+    "output.key.format": "JSON_SR",
+    "plugin.name": "pgoutput",
+    "publication.name": "dbz_publication",
+    "slot.name": "debezium_slot",
+    "snapshot.mode": "initial",
+    "tombstones.on.delete": "true",
+    "heartbeat.interval.ms": "30000",
+    "tasks.max": "1"
+  }
+)
+```
+
+**Verify connector provisioning:**
+Managed connectors take **2-5 minutes** to provision. Poll status:
+```
+mcp__confluent__read-connector(connectorName, environmentId, clusterId)
+```
+- `tasks: []` → Still provisioning, wait and retry
+- `tasks: [{...}]` → Provisioned, tasks assigned
+
+**Verify data is flowing:**
+```
+mcp__confluent__list-schemas(subjectPrefix: "postgres-cdc")
+```
+When schemas appear (e.g., `postgres-cdc.public.customers-key`, `postgres-cdc.public.customers-value`), the connector is producing data.
+
+If no schemas appear after 5 minutes with tasks assigned, check database connectivity and credentials. The MCP `read-connector` tool does NOT show error logs — use the Confluent Cloud UI for connector error details.
+
+#### 3.2 Execute Flink SQL
+
+**Step 1: Verify CDC table is auto-discovered:**
+```
+mcp__confluent__create-flink-statement(
+  statementName: "show-tables-check",
+  statement: "SHOW TABLES;",
+  environmentId: "<env-id>",
+  computePoolId: "<pool-id>",
+  catalogName: "<environment-display-name>",
+  databaseName: "<cluster-display-name>"
+)
+```
+Then read results:
+```
+mcp__confluent__read-flink-statement(statementName: "show-tables-check", environmentId: "<env-id>")
+```
+Look for the CDC topic table (e.g., `postgres-cdc.public.customers`). If not present, the connector hasn't produced data yet — wait and retry.
+
+**Step 2: Create target table:**
+```
+mcp__confluent__create-flink-statement(
+  statementName: "cdc-create-target-customers",
+  statement: "CREATE TABLE `target_customers` (...) WITH ('changelog.mode' = 'upsert');",
+  environmentId, computePoolId, catalogName, databaseName
+)
+```
+
+**Step 3: Create INSERT job:**
+```
+mcp__confluent__create-flink-statement(
+  statementName: "cdc-decode-customers",
+  statement: "INSERT INTO `target_customers` SELECT ... FROM `postgres-cdc.public.customers`;",
+  environmentId, computePoolId, catalogName, databaseName
+)
+```
+
+The INSERT creates a continuous Flink job. Verify it transitions to RUNNING (not FAILED):
+```
+mcp__confluent__read-flink-statement(statementName: "cdc-decode-customers", environmentId)
+```
+
+**Common INSERT failures:**
+- "Table does not exist" → CDC source table not yet auto-discovered; wait for connector
+- "Incompatible types for sink column" → Type mismatch; check Debezium type mappings above
+- "Unsupported format" → Remove any explicit format properties from CREATE TABLE
+
+**Advisory warnings (can be ignored):**
+- "Primary key does not match upsert key" — Expected for CDC decode patterns
+- "Highly state-intensive operators without TTL" — Advisory; set TTL if needed for production
+
+#### 3.3 Enable Tableflow
+
+**Using MCP:**
+```
+mcp__confluent__create-tableflow-topic(
+  tableflowTopicConfig: {
+    "display_name": "target_customers",
+    "storage": { "kind": "Managed", "bucket_name": "managed", "provider_integration_id": "managed" },
+    "table_formats": ["ICEBERG"],
+    "config": { "record_failure_strategy": "SUSPEND", "retention_ms": "6048000000" }
+  }
+)
+```
+
+**KNOWN LIMITATION:** The MCP `create-tableflow-topic` tool does NOT accept `environmentId` or `clusterId` parameters. It defaults to the cluster configured in the MCP server's `BOOTSTRAP_SERVERS` (from the `.env` file). If the MCP server points to a different cluster than where the target topic exists, this will fail with "topic not found".
+
+**Workarounds if MCP Tableflow creation fails:**
+1. **Update the MCP `.env` file** to point to the correct cluster, reconnect with `/mcp`, then retry
+2. **Use the Confluent Cloud UI**: Environment → Cluster → Topics → `target_customers` → Tableflow tab → Enable
+
+**Verify Tableflow is enabled:**
+```
+mcp__confluent__list-tableflow-topics(environmentId, clusterId)
+```
+Status will transition from `PENDING` → `ACTIVE`.
+
+### Phase 4: Verification & Troubleshooting
+
+#### 4.1 Verify End-to-End Pipeline
+
+**Check each component:**
+
+| Check | MCP Tool | What to Look For |
+|-------|----------|-----------------|
+| Connector running | `read-connector` | `tasks` array is non-empty |
+| Schemas registered | `list-schemas(subjectPrefix)` | Key and value schemas for CDC topic |
+| CDC table in Flink | `create-flink-statement("SHOW TABLES")` | CDC topic appears as table |
+| Flink job running | `read-flink-statement` | No error in response |
+| Target topic has data | `consume-messages(topicNames)` | Messages appear (note: consumer starts at latest offset) |
+| Tableflow enabled | `list-tableflow-topics` | Status is PENDING or ACTIVE |
+
+**Consume from target topic to verify decoded data:**
+```
+mcp__confluent__consume-messages(
+  topicNames: ["target_customers"],
+  value: { "useSchemaRegistry": true },
+  key: { "useSchemaRegistry": true },
+  maxMessages: 5,
+  timeoutMs: 15000
+)
+```
+
+Note: The consumer starts at the latest offset. If the initial snapshot already completed, you may see 0 messages until a new database change occurs.
+
+**Test real-time CDC by inserting a row in the source database:**
+```sql
+INSERT INTO public.customers (name, email, created_at)
+VALUES ('Test User', 'test@example.com', NOW());
+```
+
+#### 4.2 Troubleshooting
+
+For detailed troubleshooting, see `references/troubleshooting.md`.
+
+**Quick reference for common issues:**
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Connector creation fails: "topic.prefix is required" | Missing required field | Add `"topic.prefix"` to connector config |
+| Connector tasks stay empty | Still provisioning | Wait 2-5 minutes, retry |
+| No schemas after 5 min | DB connectivity or credentials | Check host, port, user, password; verify DB CDC config |
+| SHOW TABLES missing CDC table | Connector not producing yet | Verify schemas exist first, then wait |
+| CREATE TABLE: "Unsupported format" | Explicit format specs | Remove all `'value.format'`, `'connector'` properties |
+| INSERT: "Incompatible types" | Debezium type mismatch | Use TIMESTAMP_LTZ(3) + TO_TIMESTAMP_LTZ conversion |
+| Tableflow: "topic not found" | MCP cluster mismatch | Update MCP `.env` file or use Cloud UI |
+| consume-messages returns 0 | Consumer at latest offset | Insert a new row in DB, or MCP targets wrong cluster |
+
+### Phase 5: Documentation
+
+After successful setup, provide the user with:
+
+1. **Pipeline Summary Table**: All component names, IDs, and statuses
+2. **Topic Names**: Source CDC topic and target JSON_SR topic
+3. **Monitoring**: Check connector, Flink job, and Tableflow status in Confluent Cloud UI
+4. **Test Command**: SQL INSERT to verify real-time CDC
+5. **MCP `.env` Config**: Note which `.env` file was used and the environment/cluster defaults extracted from it
+
+## Important Notes
+
+- **Tableflow is NOT a connector** — It's a native topic feature enabled via API or UI
+- **Cloud Flink auto-discovers CDC tables** — No manual source table creation needed
+- **Managed connectors use `output.data.format`** — Not converter classes
+- **`topic.prefix` is REQUIRED** — Controls topic naming for all CDC V2 connectors
+- **Schema Evolution**: Database schema changes require updating Flink target table and INSERT job
+- **Scaling**: Increase Flink compute pool CFU for higher throughput
+- **Cost**: CDC connectors, Flink CFUs, and Tableflow all incur costs
+- **Tableflow works with any cluster type** — Basic, Standard, Dedicated, and Enterprise clusters all support Tableflow
+- **MCP `.env` file is the source of truth** — Read the `.env` file referenced in `.mcp.json` for default environment, cluster, Flink, and Schema Registry config
+- **MCP cluster targeting**: The MCP server targets the cluster specified in the `.env` file's `BOOTSTRAP_SERVERS`
+
+## References
+
+- Database Prerequisites: `references/database-prerequisites.md`
+- Connector Configurations: `references/connector-configs.md`
+- Flink SQL Patterns: `references/flink-sql-patterns.md`
+- Troubleshooting Guide: `references/troubleshooting.md`
+- Confluent Cloud Flink Docs: https://docs.confluent.io/cloud/current/flink/overview.html
+- Tableflow Docs: https://docs.confluent.io/cloud/current/topics/tableflow/overview.html
+- Debezium CDC Docs: https://debezium.io/documentation/
+- Confluent MCP Server: https://github.com/confluentinc/mcp-confluent

--- a/skills/confluent-cloud-cdc-tableflow/SKILL.md
+++ b/skills/confluent-cloud-cdc-tableflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: confluent-cloud-cdc-tableflow
-description: Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill whenever users mention CDC, Debezium, Tableflow, streaming database changes, replication to data lakes, real-time data pipelines from databases, or want to stream changes from SQL Server, MySQL, PostgreSQL, Oracle, or DynamoDB to Iceberg or Delta Lake. Also trigger for phrases like "set up database replication", "stream database to data lake", "capture database changes", "sync database to Iceberg/Delta", or any mention of connecting databases to Confluent Cloud with Schema Registry.
+description: Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill when users want to capture database changes and materialize them into Iceberg or Delta Lake tables via Confluent Cloud Tableflow. Trigger phrases include "CDC to Tableflow", "database to Iceberg", "database to Delta Lake", "stream database changes to data lake", or "set up Tableflow pipeline". Do NOT trigger for general CDC, Debezium, or database replication requests that do not involve Tableflow or Iceberg/Delta Lake as the destination.
 ---
 
 # Confluent Cloud CDC to Tableflow Pipeline
@@ -70,42 +70,28 @@ confluent kafka topic list --cluster <cluster-id> --environment <env-id>
 confluent schema-registry subject list --environment <env-id>
 ```
 
-#### 0.2 Read MCP Environment File for Defaults (CRITICAL)
+#### 0.2 Gather Confluent Cloud Details from the User
 
-**Before asking the user for environment/cluster details, read the MCP server's `.env` file to extract defaults.** The `.env` file path is specified in the project's `.mcp.json` (look for the `-e` flag in the `args` array). If not found there, check `~/.config/claude/mcp.json` for an `envFile` field.
+Ask the user to provide the following Confluent Cloud details:
 
-Read the `.env` file and extract these defaults:
-
-| .env Variable | Purpose | Use As Default For |
+| Detail | Example | Used For |
 |---|---|---|
-| `KAFKA_ENV_ID` | Environment ID | `environmentId` in all MCP calls |
-| `KAFKA_CLUSTER_ID` | Kafka cluster ID | `clusterId` in all MCP calls |
-| `BOOTSTRAP_SERVERS` | Kafka bootstrap endpoint | MCP cluster targeting |
-| `KAFKA_API_KEY` / `KAFKA_API_SECRET` | Cluster-scoped Kafka API keys | Connector `kafka.api.key` / `kafka.api.secret` |
-| `FLINK_COMPUTE_POOL_ID` | Flink compute pool | `computePoolId` in Flink statements |
-| `FLINK_ENV_NAME` | Flink catalog name | `catalogName` in Flink statements |
-| `FLINK_DATABASE_NAME` | Flink database name | `databaseName` in Flink statements |
-| `FLINK_REST_ENDPOINT` | Flink API base URL | `baseUrl` for Flink MCP calls |
-| `FLINK_ORG_ID` | Organization ID | `organizationId` in Flink MCP calls |
-| `SCHEMA_REGISTRY_ENDPOINT` | Schema Registry URL | Verification only |
+| Environment ID | `env-0ypxv6` | `environmentId` in all MCP calls |
+| Kafka Cluster ID | `lkc-qo5k36` | `clusterId` in all MCP calls |
+| Flink Compute Pool ID | `lfcp-3v39xw` | `computePoolId` in Flink statements |
+| Flink Catalog Name | `my_environment` | `catalogName` in Flink statements |
+| Flink Database Name | `cluster_0` | `databaseName` in Flink statements |
 
-**If the `.env` file contains these values**, present them to the user and ask for confirmation before proceeding. For example:
+**Credentials:** Ask the user to either provide credentials directly or point to a file containing them. The following credentials are needed:
 
-> "I found the following targets in your MCP `.env` file:
-> - **Environment:** `env-0ypxv6`
-> - **Cluster:** `lkc-qo5k36` (bootstrap: `pkc-921jm.us-east-2.aws.confluent.cloud:9092`)
-> - **Flink Compute Pool:** `lfcp-3v39xw` (catalog: `erick_cdc_tableflow_test`, database: `cluster_0`)
-> - **Schema Registry:** `psrc-19262jq.us-east-2.aws.confluent.cloud`
->
-> Should I use these for the pipeline, or would you like to target a different environment/cluster?"
-
-If the user confirms, use these values throughout the pipeline. If they want different targets, ask them to specify.
-
-**If the `.env` file is not found or missing key variables**, ask the user which environment and cluster to use, then fall back to discovering via `mcp__confluent__list-environments` and `mcp__confluent__list-clusters`.
+| Credential | Purpose | Notes |
+|---|---|---|
+| Kafka API Key | Connector authentication to Kafka cluster | `kafka.auth.mode` supports both `SERVICE_ACCOUNT` and `KAFKA_API_KEY` ([docs](https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-debezium/cc-postgresql-cdc-source-v2-debezium.html#kafka-cluster-credentials)) |
+| Kafka API Secret | Connector authentication to Kafka cluster | Paired with the API key above |
+| Database Username | Connector authentication to source database | For database authentication via password |
+| Database Password | Connector authentication to source database | Also supports Google Service Account impersonation for GCP-hosted databases |
 
 #### 0.3 Verify MCP Cluster Targeting
-
-The MCP server's `BOOTSTRAP_SERVERS` and `KAFKA_API_KEY` from the `.env` file determine which cluster it targets for Kafka operations (consume, list-topics, create-tableflow-topic).
 
 **Quick verification:**
 1. Run `mcp__confluent__list-topics` to confirm the MCP server is connected to the expected cluster
@@ -138,10 +124,10 @@ Ask the user:
 - Credentials (username, password)
 - Specific tables to capture (format: `schema.table`)
 
-**Kafka API Keys:**
-- The CDC connector needs Kafka API keys scoped to the target cluster
-- If the MCP `.env` file contains `KAFKA_API_KEY` and `KAFKA_API_SECRET`, use those as defaults
-- Only ask the user for Kafka API keys if they are not present in the `.env` file
+**Kafka & Database Credentials:**
+- The CDC connector needs Kafka API keys scoped to the target cluster and database credentials
+- Ask the user to provide these directly or point to a file containing them
+- See Phase 0.2 for the full list of required credentials and supported authentication modes
 
 **Tableflow Destination:**
 - Target format: Iceberg or Delta Lake
@@ -168,19 +154,7 @@ Generate the complete configuration plan and present it to the user for approval
 
 #### 2.1 Connector Configuration
 
-Based on the database type, generate the connector configuration. See `references/connector-configs.md` for templates.
-
-**Required fields for ALL CDC V2 connectors:**
-- `connector.class`: The connector class (e.g., `PostgresCdcSourceV2`)
-- `topic.prefix`: **REQUIRED** — Controls topic naming. Topics will be named `{topic.prefix}.{schema}.{table}`
-- `kafka.api.key` / `kafka.api.secret`: Kafka API keys for the target cluster
-- `output.data.format`: `JSON_SR` (default, recommended — uses JSON serializer with schema ID in header, safer for downstream consumers)
-- `output.key.format`: `JSON_SR`
-- `snapshot.mode`: `initial` (snapshot + stream), `never` (stream only)
-- `tombstones.on.delete`: `true`
-- `decimal.handling.mode`: `string` — **Always include for all connectors.** Without it, Debezium serializes DECIMAL/NUMERIC columns as raw bytes, producing garbled data in Flink and other downstream consumers. Affects PostgreSQL (DECIMAL, NUMERIC, MONEY), MySQL (DECIMAL, NUMERIC), SQL Server (DECIMAL, NUMERIC, MONEY, SMALLMONEY), and Oracle (NUMBER, FLOAT).
-- `binary.handling.mode`: `base64` — Include if tables have binary columns (BYTEA, VARBINARY, BLOB, RAW). Default `bytes` breaks JSON serialization.
-- `tasks.max`: `1` (recommended for CDC)
+Based on the database type, generate the connector configuration using the appropriate template from `references/connector-configs.md`. The templates include all required fields (`name`, `connector.class`, `topic.prefix`, `kafka.api.key`, `output.data.format`, `decimal.handling.mode`, etc.) and database-specific settings.
 
 **Topic Naming Pattern:**
 `{topic.prefix}.{schema}.{table}`
@@ -189,6 +163,8 @@ Example with `topic.prefix = "postgres-cdc"`: `postgres-cdc.public.customers`
 #### 2.2 Flink SQL Statements
 
 In Confluent Cloud Flink, the CDC source table is **auto-discovered** from the Kafka topic. You only need to:
+
+**Note:** The examples below use a `customers` table with illustrative column names. Substitute the user's actual table name, columns, and types based on the schema discovered from their CDC topic.
 
 1. **Create a target table** (for plain JSON_SR output to Tableflow):
 ```sql
@@ -260,34 +236,15 @@ Execute step-by-step using MCP tools, checking status after each component.
 
 #### 3.1 Create CDC Source Connector
 
+Build the connector configuration using the template for the user's database type from `references/connector-configs.md`. Each template includes all required fields, including the `name` field.
+
 **Using MCP:**
 ```
 mcp__confluent__create-connector(
-  connectorName: "cdc-pipeline-skill-postgres-20260323-connector",
+  connectorName: "<connector-name>",
   environmentId: "<env-id>",
   clusterId: "<cluster-id>",
-  connectorConfig: {
-    "connector.class": "PostgresCdcSourceV2",
-    "topic.prefix": "postgres-cdc",
-    "database.hostname": "<host>",
-    "database.port": "5432",
-    "database.user": "<user>",
-    "database.password": "<password>",
-    "database.dbname": "<dbname>",
-    "table.include.list": "public.customers",
-    "kafka.api.key": "<KAFKA_API_KEY>",
-    "kafka.api.secret": "<KAFKA_API_SECRET>",
-    "output.data.format": "JSON_SR",
-    "output.key.format": "JSON_SR",
-    "plugin.name": "pgoutput",
-    "publication.name": "dbz_publication",
-    "slot.name": "debezium_slot",
-    "snapshot.mode": "initial",
-    "tombstones.on.delete": "true",
-    "decimal.handling.mode": "string",
-    "heartbeat.interval.ms": "30000",
-    "tasks.max": "1"
-  }
+  connectorConfig: { <config from references/connector-configs.md> }
 )
 ```
 
@@ -372,11 +329,10 @@ mcp__confluent__create-tableflow-topic(
 )
 ```
 
-**KNOWN LIMITATION:** The MCP `create-tableflow-topic` tool does NOT accept `environmentId` or `clusterId` parameters. It defaults to the cluster configured in the MCP server's `BOOTSTRAP_SERVERS` (from the `.env` file). If the MCP server points to a different cluster than where the target topic exists, this will fail with "topic not found".
+**KNOWN LIMITATION:** The MCP `create-tableflow-topic` tool does NOT accept `environmentId` or `clusterId` parameters. It defaults to the cluster configured in the MCP server. If the MCP server points to a different cluster than where the target topic exists, this will fail with "topic not found".
 
-**Workarounds if MCP Tableflow creation fails:**
-1. **Update the MCP `.env` file** to point to the correct cluster, reconnect with `/mcp`, then retry
-2. **Use the Confluent Cloud UI**: Environment → Cluster → Topics → `target_customers` → Tableflow tab → Enable
+**Workaround if MCP Tableflow creation fails:**
+- **Use the Confluent Cloud UI**: Environment → Cluster → Topics → `target_customers` → Tableflow tab → Enable
 
 **Verify Tableflow is enabled:**
 ```
@@ -412,7 +368,7 @@ mcp__confluent__consume-messages(
 
 Note: The consumer starts at the latest offset. If the initial snapshot already completed, you may see 0 messages until a new database change occurs.
 
-**Test real-time CDC by inserting a row in the source database:**
+**Test real-time CDC by inserting a row in the source database** (adapt table name and columns to match the user's actual schema):
 ```sql
 INSERT INTO public.customers (name, email, created_at)
 VALUES ('Test User', 'test@example.com', NOW());
@@ -433,7 +389,7 @@ For detailed troubleshooting, see `references/troubleshooting.md`.
 | SHOW TABLES missing CDC table | Connector not producing yet | Verify schemas exist first, then wait |
 | CREATE TABLE: "Unsupported format" | Explicit format specs | Remove all `'value.format'`, `'connector'` properties |
 | INSERT: "Incompatible types" | Debezium type mismatch | Use TIMESTAMP_LTZ(3) + TO_TIMESTAMP_LTZ conversion |
-| Tableflow: "topic not found" | MCP cluster mismatch | Update MCP `.env` file or use Cloud UI |
+| Tableflow: "topic not found" | MCP cluster mismatch | Use Confluent Cloud UI to enable Tableflow |
 | DECIMAL columns show garbled bytes | Missing `decimal.handling.mode` | Add `"decimal.handling.mode": "string"` to connector config; must fix at connector level, not Flink |
 | INTERVAL columns show large integers | Missing `interval.handling.mode` | Add `"interval.handling.mode": "string"` for PG/Oracle; default is lossy microseconds |
 | Binary columns break JSON | Missing `binary.handling.mode` | Add `"binary.handling.mode": "base64"` for BYTEA/VARBINARY/BLOB/RAW columns |
@@ -449,7 +405,6 @@ After successful setup, provide the user with:
 2. **Topic Names**: Source CDC topic and target JSON_SR topic
 3. **Monitoring**: Check connector, Flink job, and Tableflow status in Confluent Cloud UI
 4. **Test Command**: SQL INSERT to verify real-time CDC
-5. **MCP `.env` Config**: Note which `.env` file was used and the environment/cluster defaults extracted from it
 
 ## Important Notes
 
@@ -461,8 +416,7 @@ After successful setup, provide the user with:
 - **Scaling**: Increase Flink compute pool CFU for higher throughput
 - **Cost**: CDC connectors, Flink CFUs, and Tableflow all incur costs
 - **Tableflow works with any cluster type** — Basic, Standard, Dedicated, and Enterprise clusters all support Tableflow
-- **MCP `.env` file is the source of truth** — Read the `.env` file referenced in `.mcp.json` for default environment, cluster, Flink, and Schema Registry config
-- **MCP cluster targeting**: The MCP server targets the cluster specified in the `.env` file's `BOOTSTRAP_SERVERS`
+- **Ask the user for credentials** — Request Kafka API keys and database credentials directly or ask for a file reference containing them. Supports `SERVICE_ACCOUNT` and `KAFKA_API_KEY` auth modes for Kafka, and password or Google Service Account impersonation for databases.
 
 ## References
 

--- a/skills/confluent-cloud-cdc-tableflow/SKILL.md
+++ b/skills/confluent-cloud-cdc-tableflow/SKILL.md
@@ -82,7 +82,7 @@ Ask the user to provide the following Confluent Cloud details:
 | Flink Catalog Name | `my_environment` | `catalogName` in Flink statements |
 | Flink Database Name | `cluster_0` | `databaseName` in Flink statements |
 
-**Credentials:** Ask the user to either provide credentials directly or point to a file containing them. The following credentials are needed:
+**Credentials:** Do NOT ask the user to paste credentials in the terminal. Instead, generate a credentials file (e.g., `cdc-credentials.properties`) with placeholder values for the required credentials below, and ask the user to populate it in their editor. When needed for connector creation, read the file to populate the connector config. Ensure the file is added to `.gitignore`. If the user prefers that Claude not read the credentials file, fall back to the Confluent CLI: generate a `connector-config.json` with the credentials as placeholders, let the user fill it in, then run `confluent connect cluster create --config-file connector-config.json` so the CLI reads the file directly. The following credentials are needed:
 
 | Credential | Purpose | Notes |
 |---|---|---|
@@ -121,12 +121,12 @@ Ask the user:
 **Database Configuration:**
 - Database type (SQL Server, MySQL, PostgreSQL, Oracle, or DynamoDB)
 - Connection details (hostname, port, database name)
-- Credentials (username, password)
+- Credentials (populated by the user in the credentials file)
 - Specific tables to capture (format: `schema.table`)
 
 **Kafka & Database Credentials:**
 - The CDC connector needs Kafka API keys scoped to the target cluster and database credentials
-- Ask the user to provide these directly or point to a file containing them
+- Credentials should be populated by the user in the generated credentials file — read the file when needed for connector creation, or fall back to CLI if the user prefers Claude not read credentials
 - See Phase 0.2 for the full list of required credentials and supported authentication modes
 
 **Tableflow Destination:**
@@ -416,7 +416,7 @@ After successful setup, provide the user with:
 - **Scaling**: Increase Flink compute pool CFU for higher throughput
 - **Cost**: CDC connectors, Flink CFUs, and Tableflow all incur costs
 - **Tableflow works with any cluster type** — Basic, Standard, Dedicated, and Enterprise clusters all support Tableflow
-- **Ask the user for credentials** — Request Kafka API keys and database credentials directly or ask for a file reference containing them. Supports `SERVICE_ACCOUNT` and `KAFKA_API_KEY` auth modes for Kafka, and password or Google Service Account impersonation for databases.
+- **Generate a credentials file** — Create a sample credentials file with placeholders for Kafka API keys and database credentials. Ask the user to fill it in. Do NOT ask the user to paste credentials in the terminal. Read the file when needed for connector creation via MCP. If the user prefers Claude not read credentials, fall back to the Confluent CLI (`confluent connect cluster create --config-file connector-config.json`). Supports `SERVICE_ACCOUNT` and `KAFKA_API_KEY` auth modes for Kafka, and password or Google Service Account impersonation for databases.
 
 ## References
 

--- a/skills/confluent-cloud-cdc-tableflow/SKILL.md
+++ b/skills/confluent-cloud-cdc-tableflow/SKILL.md
@@ -178,6 +178,8 @@ Based on the database type, generate the connector configuration. See `reference
 - `output.key.format`: `JSON_SR`
 - `snapshot.mode`: `initial` (snapshot + stream), `never` (stream only)
 - `tombstones.on.delete`: `true`
+- `decimal.handling.mode`: `string` — **Always include for all connectors.** Without it, Debezium serializes DECIMAL/NUMERIC columns as raw bytes, producing garbled data in Flink and other downstream consumers. Affects PostgreSQL (DECIMAL, NUMERIC, MONEY), MySQL (DECIMAL, NUMERIC), SQL Server (DECIMAL, NUMERIC, MONEY, SMALLMONEY), and Oracle (NUMBER, FLOAT).
+- `binary.handling.mode`: `base64` — Include if tables have binary columns (BYTEA, VARBINARY, BLOB, RAW). Default `bytes` breaks JSON serialization.
 - `tasks.max`: `1` (recommended for CDC)
 
 **Topic Naming Pattern:**
@@ -224,6 +226,9 @@ FROM `postgres-cdc.public.customers`;
 | `MicroTimestamp` | BIGINT (microseconds) | TIMESTAMP_LTZ(3) | `TO_TIMESTAMP_LTZ(col / 1000, 3)` |
 | `Timestamp` | BIGINT (milliseconds) | TIMESTAMP_LTZ(3) | `TO_TIMESTAMP_LTZ(col, 3)` |
 | `Date` | INT (days since epoch) | DATE | Direct or cast |
+| `DECIMAL`/`NUMERIC` | STRING (with `decimal.handling.mode=string`) | DECIMAL or STRING | Direct; without `string` mode, arrives as BYTES which Flink cannot cast |
+| `INTERVAL` (PG/Oracle) | STRING (with `interval.handling.mode=string`) | STRING | Direct; default `numeric` mode is lossy |
+| Binary (BYTEA, BLOB, etc.) | STRING (with `binary.handling.mode=base64`) | STRING | Base64-encoded; default `bytes` breaks JSON |
 | Numeric/String | Direct mapping | Same | No conversion needed |
 
 For detailed patterns, see `references/flink-sql-patterns.md`.
@@ -279,6 +284,7 @@ mcp__confluent__create-connector(
     "slot.name": "debezium_slot",
     "snapshot.mode": "initial",
     "tombstones.on.delete": "true",
+    "decimal.handling.mode": "string",
     "heartbeat.interval.ms": "30000",
     "tasks.max": "1"
   }
@@ -423,10 +429,16 @@ For detailed troubleshooting, see `references/troubleshooting.md`.
 | Connector creation fails: "topic.prefix is required" | Missing required field | Add `"topic.prefix"` to connector config |
 | Connector tasks stay empty | Still provisioning | Wait 2-5 minutes, retry |
 | No schemas after 5 min | DB connectivity or credentials | Check host, port, user, password; verify DB CDC config |
+| MySQL: "LOCK TABLES privilege required" | Managed MySQL lacks SUPER privilege | `GRANT LOCK TABLES ON db.* TO 'user'@'%';` — required for RDS, Aurora, Cloud SQL, Azure MySQL |
 | SHOW TABLES missing CDC table | Connector not producing yet | Verify schemas exist first, then wait |
 | CREATE TABLE: "Unsupported format" | Explicit format specs | Remove all `'value.format'`, `'connector'` properties |
 | INSERT: "Incompatible types" | Debezium type mismatch | Use TIMESTAMP_LTZ(3) + TO_TIMESTAMP_LTZ conversion |
 | Tableflow: "topic not found" | MCP cluster mismatch | Update MCP `.env` file or use Cloud UI |
+| DECIMAL columns show garbled bytes | Missing `decimal.handling.mode` | Add `"decimal.handling.mode": "string"` to connector config; must fix at connector level, not Flink |
+| INTERVAL columns show large integers | Missing `interval.handling.mode` | Add `"interval.handling.mode": "string"` for PG/Oracle; default is lossy microseconds |
+| Binary columns break JSON | Missing `binary.handling.mode` | Add `"binary.handling.mode": "base64"` for BYTEA/VARBINARY/BLOB/RAW columns |
+| Oracle NUMBER produces struct not scalar | Oracle NUMBER without precision | Add `"decimal.handling.mode": "string"` — default produces VariableScaleDecimal struct |
+| Flink DEGRADED: "Schema ID not found" | Stale schema IDs on topics after schema deletion | Delete CDC source topics + hard-delete schemas + drop replication slot, then recreate connector fresh |
 | consume-messages returns 0 | Consumer at latest offset | Insert a new row in DB, or MCP targets wrong cluster |
 
 ### Phase 5: Documentation

--- a/skills/confluent-cloud-cdc-tableflow/SKILL.md
+++ b/skills/confluent-cloud-cdc-tableflow/SKILL.md
@@ -1,14 +1,6 @@
 ---
 name: confluent-cloud-cdc-tableflow
-description: |
-  Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill whenever users mention CDC, Debezium, Tableflow, streaming database changes, replication to data lakes, real-time data pipelines from databases, or want to stream changes from SQL Server, MySQL, PostgreSQL, Oracle, or DynamoDB to Iceberg or Delta Lake. Also trigger for phrases like "set up database replication", "stream database to data lake", "capture database changes", "sync database to Iceberg/Delta", or any mention of connecting databases to Confluent Cloud with Schema Registry.
-compatibility:
-  tools:
-    - Bash
-    - Read
-    - Write
-    - Edit
-    - mcp__confluent__* (Confluent MCP Server - preferred for all operations)
+description: Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill whenever users mention CDC, Debezium, Tableflow, streaming database changes, replication to data lakes, real-time data pipelines from databases, or want to stream changes from SQL Server, MySQL, PostgreSQL, Oracle, or DynamoDB to Iceberg or Delta Lake. Also trigger for phrases like "set up database replication", "stream database to data lake", "capture database changes", "sync database to Iceberg/Delta", or any mention of connecting databases to Confluent Cloud with Schema Registry.
 ---
 
 # Confluent Cloud CDC to Tableflow Pipeline

--- a/skills/confluent-cloud-cdc-tableflow/evals/evals.json
+++ b/skills/confluent-cloud-cdc-tableflow/evals/evals.json
@@ -1,0 +1,95 @@
+{
+  "skill_name": "confluent-cdc-tableflow",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I need to set up a CDC pipeline from our PostgreSQL production database to an Iceberg table in S3. We have a 'users' table in the 'public' schema and an 'orders' table that I want to replicate. I don't have anything set up yet in Confluent Cloud - no connectors, no Flink pools, nothing. The PostgreSQL database is already configured for logical replication. Can you help me set this up? The database is at pg-prod.example.com:5432, database name is 'ecommerce'. For the S3 destination, use bucket 'my-data-lake' with path '/iceberg/tables/'.",
+      "expected_output": "Complete setup plan including: (1) PostgreSQL CDC connector configuration with correct table.include.list, (2) Flink compute pool creation, (3) Flink SQL statements for both tables (source tables with Debezium format, target tables with JSON_SR, INSERT statements to decode), (4) Tableflow sink configuration for Iceberg. Should ask for credentials before execution and present plan for approval.",
+      "files": [],
+      "assertions": [
+        {"name": "Creates PostgreSQL CDC connector configuration", "description": "Should generate a PostgreSQL CDC V2 connector config file (JSON)"},
+        {"name": "Includes both tables in connector config", "description": "Connector config should have table.include.list with 'public.users' and 'public.orders'"},
+        {"name": "Uses JSON_SR format", "description": "Connector config should specify output.data.format = JSON_SR"},
+        {"name": "Creates Flink compute pool", "description": "Should include commands or plan to create a Flink compute pool"},
+        {"name": "Generates Flink SQL for both tables", "description": "Should create source and target table DDL plus INSERT statements for users and orders"},
+        {"name": "Creates Tableflow sink configuration", "description": "Should generate Tableflow connector config for Iceberg with S3 path"},
+        {"name": "Presents plan for approval", "description": "Should present a complete plan and wait for user confirmation before executing"}
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "hey so i already have a flink compute pool running (pool id is 'lfcp-abc123') and i want to add CDC from my mysql database. it's an RDS instance at mysql-prod.us-east-1.rds.amazonaws.com, database is 'inventory', and i want to capture the 'products' and 'categories' tables. i need this going to a delta lake table, not iceberg. also i don't have a naming convention preference so just use whatever makes sense. the mysql binlog is already configured correctly.",
+      "expected_output": "Setup plan that: (1) Uses existing Flink compute pool lfcp-abc123 (no new pool creation), (2) Creates MySQL CDC connector with appropriate RDS configuration, (3) Generates Flink SQL for 2 tables, (4) Configures Tableflow for Delta Lake (not Iceberg), (5) Uses auto-generated naming convention like 'cdc-pipeline-skill-mysql-{timestamp}'. Should verify MySQL prerequisites and ask for credentials.",
+      "files": [],
+      "assertions": [
+        {"name": "Uses existing Flink pool", "description": "Should reference pool id 'lfcp-abc123' and NOT create a new Flink compute pool"},
+        {"name": "Creates MySQL CDC connector configuration", "description": "Should generate a MySQL CDC V2 connector config file (JSON)"},
+        {"name": "Includes both tables in connector config", "description": "Connector config should have table.include.list with 'inventory.products' and 'inventory.categories'"},
+        {"name": "Configures Tableflow for Delta Lake", "description": "Tableflow sink config should specify table.format = 'delta' (not iceberg)"},
+        {"name": "Generates auto naming convention", "description": "Should create consistent naming like 'cdc-pipeline-skill-mysql-*' since user has no preference"}
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "my postgres cdc connector keeps failing with status FAILED. the connector name is 'postgres-cdc-users' and it was working yesterday but now it's broken. when i check the logs it says something about 'replication slot does not exist'. can you help me troubleshoot this?",
+      "expected_output": "Troubleshooting guidance that: (1) Identifies likely cause as replication slot deletion/cleanup, (2) Provides commands to check PostgreSQL replication slots, (3) Suggests either recreating the slot or updating connector config with new slot name, (4) Explains how to verify the fix, (5) References troubleshooting.md for additional context. Should check connector logs and guide user through diagnosis steps.",
+      "files": [],
+      "assertions": [
+        {"name": "Identifies replication slot issue", "description": "Should correctly diagnose the problem as a missing/deleted replication slot"},
+        {"name": "Provides PostgreSQL diagnostic commands", "description": "Should give SQL commands to check replication slots (e.g., SELECT * FROM pg_replication_slots)"},
+        {"name": "Suggests fix for missing slot", "description": "Should provide steps to recreate the replication slot or update connector config"},
+        {"name": "Explains verification steps", "description": "Should explain how to verify the fix (check connector status, verify messages flowing)"}
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "We need to set up change data capture from our SQL Server 2019 database on Azure. The database name is 'SalesDB' and we want to capture changes from the 'dbo.Customers', 'dbo.Invoices', and 'dbo.LineItems' tables. CDC is already enabled on the database and all three tables. The server is at salesdb.database.windows.net port 1433. We want the data to end up in Iceberg format in our Azure Data Lake Storage Gen2 account at abfss://analytics@mycompany.dfs.core.windows.net/cdc/sales/. I'd prefer to use JSON with Schema Registry instead of Avro if that's possible. We already have naming conventions - use prefix 'sales-cdc-' for everything.",
+      "expected_output": "Setup plan that: (1) Creates SQL Server CDC V2 connector with dbo.Customers, dbo.Invoices, dbo.LineItems in table.include.list, (2) Uses JSON_SR format instead of Avro, (3) Flink compute pool creation, (4) Flink SQL for all 3 tables with JSON format, (5) Tableflow sink for Iceberg with ADLS Gen2 configuration, (6) Uses 'sales-cdc-' naming prefix throughout. Should verify SQL Server Agent is running and ask for Azure credentials.",
+      "files": [],
+      "assertions": [
+        {"name": "Creates SQL Server CDC V2 connector configuration", "description": "Should generate a SQL Server CDC V2 connector config file (JSON)"},
+        {"name": "Includes all three tables", "description": "Connector config should have table.include.list with 'dbo.Customers', 'dbo.Invoices', 'dbo.LineItems'"},
+        {"name": "Uses JSON_SR format", "description": "Connector config should specify output.data.format = JSON_SR (not AVRO)"},
+        {"name": "Configures Tableflow for ADLS Gen2", "description": "Tableflow sink should use Azure Data Lake Storage Gen2 path (abfss:// format)"},
+        {"name": "Uses sales-cdc naming prefix", "description": "All component names should start with 'sales-cdc-' as requested"}
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "I'm trying to replicate our Oracle 19c database to a data lake using XStream. The database has supplemental logging and archivelog mode enabled, and we've already created the XStream outbound server called 'dbz_outbound'. We want to capture the HR.EMPLOYEES and HR.DEPARTMENTS tables. The Oracle instance is at oracle-prod.internal:1521, service name is PRODDB. Target is S3 bucket 'enterprise-datalake' path '/oracle/hr/' using Iceberg. We have a Flink pool already (lfcp-xyz789). Can you generate the configs needed?",
+      "expected_output": "Setup plan that: (1) Creates Oracle XStream CDC connector referencing existing outbound server 'dbz_outbound', (2) Correctly formats table names as HR.EMPLOYEES and HR.DEPARTMENTS (uppercase), (3) Uses existing Flink pool lfcp-xyz789, (4) Generates Flink SQL for Oracle-specific setup, (5) Tableflow sink for Iceberg/S3. Should verify Oracle prerequisites (archivelog, supplemental logging) are met and ask for Oracle credentials.",
+      "files": [],
+      "assertions": [
+        {"name": "Creates Oracle XStream connector configuration", "description": "Should generate an Oracle XStream CDC connector config file (JSON)"},
+        {"name": "References existing outbound server", "description": "Connector config should reference 'dbz_outbound' as the XStream outbound server"},
+        {"name": "Uses uppercase table names", "description": "Connector config should use uppercase table names: 'HR.EMPLOYEES', 'HR.DEPARTMENTS'"},
+        {"name": "Uses existing Flink pool", "description": "Should reference pool id 'lfcp-xyz789' and NOT create a new Flink compute pool"}
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "need help setting up cdc from dynamodb. we have a table called 'user-sessions' in us-west-2 that has streams enabled (NEW_AND_OLD_IMAGES). want to push this to delta lake in s3://analytics-bucket/dynamodb-cdc/sessions/. pretty straightforward setup, no flink pool exists yet. use whatever defaults make sense.",
+      "expected_output": "Setup plan that: (1) Creates DynamoDB CDC connector for 'user-sessions' table, (2) Configures for us-west-2 region, (3) Verifies streams are enabled with NEW_AND_OLD_IMAGES, (4) Creates Flink compute pool, (5) Flink SQL to process DynamoDB streams format, (6) Tableflow sink for Delta Lake. Should ask for AWS credentials (IAM user/role with DynamoDB Streams permissions) and generate auto naming convention.",
+      "files": [],
+      "assertions": [
+        {"name": "Creates DynamoDB CDC connector configuration", "description": "Should generate a DynamoDB CDC connector config file (JSON)"},
+        {"name": "Configures for us-west-2 region", "description": "Connector config should specify aws.dynamodb.region = us-west-2"},
+        {"name": "Includes user-sessions table", "description": "Connector config should have table.include.list with 'user-sessions'"},
+        {"name": "Configures Tableflow for Delta Lake", "description": "Tableflow sink should specify table.format = 'delta' with S3 path"}
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "We have an existing CDC pipeline running from PostgreSQL to Iceberg that's been working great for 3 months. The connector is 'postgres-cdc-customers', Flink pool is 'lfcp-customers-001', and it's capturing the public.customers table. Now the database team just added a new column 'loyalty_tier' (varchar 20, nullable) to the customers table in PostgreSQL. The column is already there in production. What do I need to do to update the pipeline to include this new column? I want to make sure we don't lose any data or break the existing pipeline.",
+      "expected_output": "Schema evolution guidance that: (1) Explains the column is nullable so it's a compatible change, (2) Steps to update Flink source table DDL to include new column, (3) Steps to update Flink target table DDL, (4) How to stop and restart the Flink INSERT statement, (5) Verification steps to ensure new column data flows through, (6) Notes about Schema Registry compatibility and Tableflow handling the new column automatically. Should reference flink-sql-patterns.md Pattern 5 for schema evolution.",
+      "files": [],
+      "assertions": [
+        {"name": "Identifies compatible schema change", "description": "Should recognize that adding a nullable column is a compatible/safe schema change"},
+        {"name": "Provides steps to update Flink source table", "description": "Should explain how to drop and recreate the source table DDL with new column"},
+        {"name": "Provides steps to update Flink target table", "description": "Should explain how to drop and recreate the target table DDL with new column"},
+        {"name": "Explains how to restart INSERT statement", "description": "Should provide commands to stop existing INSERT statement and start new one"},
+        {"name": "References schema evolution pattern", "description": "Should mention or reference Pattern 5 from flink-sql-patterns.md"}
+      ]
+    }
+  ]
+}

--- a/skills/confluent-cloud-cdc-tableflow/references/connector-configs.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/connector-configs.md
@@ -28,6 +28,9 @@ All connectors share these common settings:
   "output.data.format": "JSON_SR",
   "output.key.format": "JSON_SR",
 
+  "decimal.handling.mode": "string",
+  "binary.handling.mode": "base64",
+
   "tasks.max": "1"
 }
 ```
@@ -81,12 +84,21 @@ All connectors share these common settings:
   "heartbeat.interval.ms": "30000",
   "heartbeat.action.query": "INSERT INTO heartbeat (ts) VALUES (NOW())",
 
+  "decimal.handling.mode": "string",
+  "binary.handling.mode": "base64",
+  "interval.handling.mode": "string",
+  "hstore.handling.mode": "map",
+
   "tasks.max": "1"
 }
 ```
 
 **Key Parameters:**
 - `topic.prefix`: **REQUIRED** — Controls topic naming (e.g., `postgres-cdc`)
+- `decimal.handling.mode`: **Always set to `string`.** Without it, Debezium serializes DECIMAL/NUMERIC/MONEY columns as raw bytes (Java BigDecimal unscaled value), producing garbled data like `"N\u001f"` instead of `"199.99"`. Flink cannot CAST BYTES to DECIMAL, so this must be fixed at the connector level.
+- `interval.handling.mode`: Set to `string` for PostgreSQL INTERVAL columns. Default `numeric` approximates intervals as microseconds (months = 30 days, years = 365.25 days), which is lossy. `string` outputs ISO 8601 format like `P1Y2M3DT4H5M6.78S`.
+- `hstore.handling.mode`: Set to `map` if using PostgreSQL HSTORE columns. Default `json` serializes as a JSON string inside a STRING field; `map` produces a native Kafka Connect MAP type.
+- `binary.handling.mode`: Set to `base64` if using BYTEA columns. Default `bytes` can break JSON serialization.
 - `database.server.name`: Logical name for this database server
 - `table.include.list`: Comma-separated list of tables (format: `schema.table`)
 - `plugin.name`: Use `pgoutput` (native PostgreSQL logical replication)
@@ -141,6 +153,9 @@ https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-d
 
   "gtid.source.includes": ".*",
 
+  "decimal.handling.mode": "string",
+  "binary.handling.mode": "base64",
+
   "tasks.max": "1"
 }
 ```
@@ -148,6 +163,8 @@ https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-d
 **Key Parameters:**
 - `database.server.id`: Unique numeric ID for this connector (5-10 digits)
 - `topic.prefix`: **REQUIRED** — Controls topic naming
+- `decimal.handling.mode`: **Always set to `string`.** Same raw bytes issue as PostgreSQL for DECIMAL/NUMERIC columns.
+- `binary.handling.mode`: Set to `base64` if using BINARY/VARBINARY/BLOB columns. Default `bytes` breaks JSON serialization.
 - `database.server.name`: Logical name for this database server
 - `database.include.list`: Comma-separated list of databases
 - `table.include.list`: Comma-separated list of tables (format: `database.table`)
@@ -195,12 +212,17 @@ https://docs.confluent.io/cloud/current/connectors/cc-mysql-cdc-source-v2-debezi
 
   "include.schema.changes": "false",
 
+  "decimal.handling.mode": "string",
+  "binary.handling.mode": "base64",
+
   "tasks.max": "1"
 }
 ```
 
 **Key Parameters:**
 - `topic.prefix`: **REQUIRED** — Controls topic naming
+- `decimal.handling.mode`: **Always set to `string`.** Affects DECIMAL, NUMERIC, MONEY, and SMALLMONEY columns — same raw bytes issue as PostgreSQL.
+- `binary.handling.mode`: Set to `base64` if using BINARY/VARBINARY/IMAGE columns.
 - `database.names`: Comma-separated list of databases
 - `database.server.name`: Logical name for this database server
 - `table.include.list`: Comma-separated list of tables (format: `schema.table`, use `dbo` for default schema)
@@ -248,11 +270,18 @@ https://docs.confluent.io/cloud/current/connectors/cc-microsoft-sql-server-cdc-s
 
   "tombstones.on.delete": "true",
 
+  "decimal.handling.mode": "string",
+  "binary.handling.mode": "base64",
+  "interval.handling.mode": "string",
+
   "tasks.max": "1"
 }
 ```
 
 **Key Parameters:**
+- `decimal.handling.mode`: **Always set to `string`.** Affects `NUMBER(p,s)` columns. Oracle `NUMBER` and `FLOAT` without explicit precision are especially problematic — Debezium serializes them as `VariableScaleDecimal`, a struct containing a bytes field, which breaks differently than regular decimals.
+- `interval.handling.mode`: Set to `string` for `INTERVAL YEAR TO MONTH` and `INTERVAL DAY TO SECOND` columns. Default `numeric` approximates as microseconds, which is lossy for month/year intervals.
+- `binary.handling.mode`: Set to `base64` if using RAW or BLOB columns.
 - `database.dbname`: Oracle service name or SID
 - `database.connection.adapter`: Use `xstream` for XStream
 - `database.out.server.name`: XStream outbound server name (created in Oracle)
@@ -314,6 +343,31 @@ https://docs.confluent.io/cloud/current/connectors/cc-amazon-dynamodb-source.htm
 ---
 
 ## Configuration Best Practices
+
+### Data Type Serialization
+
+Debezium's default serialization modes can produce raw bytes, lossy approximations, or unexpected types that break downstream consumers (Flink, ksqlDB, etc.). Always include these settings for maximum interoperability:
+
+**All connectors:**
+```json
+{
+  "decimal.handling.mode": "string",
+  "binary.handling.mode": "base64"
+}
+```
+
+| Setting | Default | Problem | Recommended | Affected Types |
+|---|---|---|---|---|
+| `decimal.handling.mode` | `precise` | DECIMAL/NUMERIC serialized as raw bytes | `string` | PG: DECIMAL, NUMERIC, MONEY. MySQL: DECIMAL, NUMERIC. SQL Server: DECIMAL, NUMERIC, MONEY, SMALLMONEY. Oracle: NUMBER(p,s), NUMBER, FLOAT |
+| `binary.handling.mode` | `bytes` | Binary data breaks JSON serialization | `base64` | PG: BYTEA. MySQL: BINARY, VARBINARY, BLOB. SQL Server: BINARY, VARBINARY, IMAGE. Oracle: RAW, BLOB |
+| `interval.handling.mode` | `numeric` | Intervals approximated as microseconds (lossy) | `string` | PG: INTERVAL. Oracle: INTERVAL YEAR TO MONTH, INTERVAL DAY TO SECOND |
+| `hstore.handling.mode` | `json` | HSTORE as JSON string, not native MAP | `map` | PG: HSTORE |
+
+**Database-specific quirks with no config toggle:**
+- **MySQL `TINYINT(1)`**: Serialized as INT16, not BOOLEAN. Fix: add `converters=bool` with `TinyIntOneToBooleanConverter` (note: may not be available on all managed connector versions).
+- **MySQL `BIGINT UNSIGNED`**: Default `long` silently overflows for values > 2^63. Setting `bigint.unsigned.handling.mode = precise` avoids overflow but produces bytes (same issue as decimals).
+- **SQL Server `DATETIMEOFFSET`**: Serialized as STRING with timezone offset. Flink may not auto-parse — requires explicit cast.
+- **Oracle `NUMBER` (no precision)**: Serialized as `VariableScaleDecimal` (a struct containing bytes), not plain bytes. `decimal.handling.mode = string` fixes this.
 
 ### Secrets Management
 

--- a/skills/confluent-cloud-cdc-tableflow/references/connector-configs.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/connector-configs.md
@@ -1,0 +1,425 @@
+# Connector Configuration Templates
+
+This file contains configuration templates for each supported Debezium CDC connector type. All configurations use Schema Registry and are designed for Confluent Cloud fully-managed connectors.
+
+## Using MCP to Create Connectors
+
+**Preferred method:** Use `mcp__confluent__create-connector` with these parameters:
+- `connectorName`: The connector name
+- `environmentId`: The Confluent Cloud environment ID
+- `clusterId`: The Kafka cluster ID
+- `connectorConfig`: A flat map of string key-value pairs (the JSON config below)
+
+**Important:** The `kafka.api.key` and `kafka.api.secret` in the connector config must be scoped to the target Kafka cluster. These may differ from the MCP server's own API keys if the MCP server is configured for a different cluster.
+
+## Common Configuration Elements
+
+All connectors share these common settings:
+
+```json
+{
+  "connector.class": "<connector-class>",
+  "name": "<connector-name>",
+  "topic.prefix": "<topic-prefix>",
+
+  "kafka.api.key": "<KAFKA_API_KEY>",
+  "kafka.api.secret": "<KAFKA_API_SECRET>",
+
+  "output.data.format": "JSON_SR",
+  "output.key.format": "JSON_SR",
+
+  "tasks.max": "1"
+}
+```
+
+**REQUIRED field: `topic.prefix`** — Controls topic naming. All CDC V2 connectors require this. Topics will be named `{topic.prefix}.{schema}.{table}`.
+
+**Schema Format Options:**
+- `JSON_SR` (default, recommended — JSON with Schema Registry, uses schema ID in header which is safer for downstream consumers and won't break existing consumers)
+- `AVRO` (binary format, requires Avro-compatible consumers)
+- `PROTOBUF`
+
+**Note on managed connectors:** Fields like `kafka.auth.mode` and `kafka.endpoint` are auto-configured by Confluent Cloud when using MCP or the CLI. You only need to provide `kafka.api.key` and `kafka.api.secret`.
+
+**Provisioning time:** Managed connectors take 2-5 minutes to provision. The connector will show `tasks: []` until provisioning completes. Poll status until tasks appear.
+
+---
+
+## PostgreSQL CDC Source V2
+
+**Connector Class:** `PostgresCdcSourceV2`
+
+```json
+{
+  "connector.class": "PostgresCdcSourceV2",
+  "name": "cdc-pipeline-skill-postgres-connector",
+
+  "kafka.api.key": "${file:/secrets.properties:KAFKA_API_KEY}",
+  "kafka.api.secret": "${file:/secrets.properties:KAFKA_API_SECRET}",
+
+  "database.hostname": "<postgres-host>",
+  "database.port": "5432",
+  "database.user": "<postgres-user>",
+  "database.password": "<postgres-password>",
+  "database.dbname": "<database-name>",
+  "database.server.name": "<logical-server-name>",
+  "topic.prefix": "<topic-prefix>",
+
+  "table.include.list": "<schema>.<table1>,<schema>.<table2>",
+
+  "plugin.name": "pgoutput",
+  "publication.name": "dbz_publication",
+  "slot.name": "debezium_slot",
+
+  "output.data.format": "JSON_SR",
+  "output.key.format": "JSON_SR",
+
+  "snapshot.mode": "initial",
+
+  "tombstones.on.delete": "true",
+
+  "heartbeat.interval.ms": "30000",
+  "heartbeat.action.query": "INSERT INTO heartbeat (ts) VALUES (NOW())",
+
+  "tasks.max": "1"
+}
+```
+
+**Key Parameters:**
+- `topic.prefix`: **REQUIRED** — Controls topic naming (e.g., `postgres-cdc`)
+- `database.server.name`: Logical name for this database server
+- `table.include.list`: Comma-separated list of tables (format: `schema.table`)
+- `plugin.name`: Use `pgoutput` (native PostgreSQL logical replication)
+- `publication.name`: Publication created in PostgreSQL
+- `slot.name`: Replication slot name (must be unique)
+- `snapshot.mode`:
+  - `initial`: Snapshot existing data, then stream changes
+  - `never`: Only stream changes (no initial snapshot)
+  - `always`: Always snapshot on startup
+
+**Topic Naming:**
+Topic pattern: `<topic.prefix>.<schema>.<table>`
+
+Example: `postgres-cdc.public.users`
+
+**Documentation:**
+https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-debezium/cc-postgresql-cdc-source-v2-debezium.html
+
+---
+
+## MySQL CDC Source V2
+
+**Connector Class:** `MySqlCdcSourceV2`
+
+```json
+{
+  "connector.class": "MySqlCdcSourceV2",
+  "name": "cdc-pipeline-skill-mysql-connector",
+
+  "kafka.api.key": "${file:/secrets.properties:KAFKA_API_KEY}",
+  "kafka.api.secret": "${file:/secrets.properties:KAFKA_API_SECRET}",
+
+  "database.hostname": "<mysql-host>",
+  "database.port": "3306",
+  "database.user": "<mysql-user>",
+  "database.password": "<mysql-password>",
+  "database.server.id": "184054",
+  "database.server.name": "<logical-server-name>",
+  "topic.prefix": "<topic-prefix>",
+
+  "database.include.list": "<database-name>",
+  "table.include.list": "<database>.<table1>,<database>.<table2>",
+
+  "output.data.format": "JSON_SR",
+  "output.key.format": "JSON_SR",
+
+  "snapshot.mode": "initial",
+
+  "tombstones.on.delete": "true",
+
+  "include.schema.changes": "false",
+
+  "gtid.source.includes": ".*",
+
+  "tasks.max": "1"
+}
+```
+
+**Key Parameters:**
+- `database.server.id`: Unique numeric ID for this connector (5-10 digits)
+- `topic.prefix`: **REQUIRED** — Controls topic naming
+- `database.server.name`: Logical name for this database server
+- `database.include.list`: Comma-separated list of databases
+- `table.include.list`: Comma-separated list of tables (format: `database.table`)
+- `gtid.source.includes`: GTID filter (use `.*` for all)
+- `snapshot.mode`: Same options as PostgreSQL
+
+**Topic Naming:**
+Topic pattern: `<topic.prefix>.<database>.<table>`
+
+Example: `mysql-cdc.inventory.customers`
+
+**Documentation:**
+https://docs.confluent.io/cloud/current/connectors/cc-mysql-cdc-source-v2-debezium/cc-mysql-cdc-source-v2-debezium.html
+
+---
+
+## SQL Server CDC Source V2
+
+**Connector Class:** `SqlServerCdcSourceV2`
+
+```json
+{
+  "connector.class": "SqlServerCdcSourceV2",
+  "name": "cdc-pipeline-skill-sqlserver-connector",
+
+  "kafka.api.key": "${file:/secrets.properties:KAFKA_API_KEY}",
+  "kafka.api.secret": "${file:/secrets.properties:KAFKA_API_SECRET}",
+
+  "database.hostname": "<sqlserver-host>",
+  "database.port": "1433",
+  "database.user": "<sqlserver-user>",
+  "database.password": "<sqlserver-password>",
+  "database.names": "<database-name>",
+  "database.server.name": "<logical-server-name>",
+  "topic.prefix": "<topic-prefix>",
+
+  "table.include.list": "dbo.<table1>,dbo.<table2>",
+
+  "output.data.format": "JSON_SR",
+  "output.key.format": "JSON_SR",
+
+  "snapshot.mode": "initial",
+
+  "tombstones.on.delete": "true",
+
+  "include.schema.changes": "false",
+
+  "tasks.max": "1"
+}
+```
+
+**Key Parameters:**
+- `topic.prefix`: **REQUIRED** — Controls topic naming
+- `database.names`: Comma-separated list of databases
+- `database.server.name`: Logical name for this database server
+- `table.include.list`: Comma-separated list of tables (format: `schema.table`, use `dbo` for default schema)
+- `snapshot.mode`: Same options as PostgreSQL
+
+**Topic Naming:**
+Topic pattern: `<topic.prefix>.<schema>.<table>`
+
+Example: `sqlserver-cdc.dbo.orders`
+
+**Documentation:**
+https://docs.confluent.io/cloud/current/connectors/cc-microsoft-sql-server-cdc-source-v2-debezium/cc-microsoft-sql-server-cdc-source-v2-debezium.html
+
+---
+
+## Oracle XStream CDC Source
+
+**Connector Class:** `OracleXStreamSource`
+
+```json
+{
+  "connector.class": "OracleXStreamSource",
+  "name": "cdc-pipeline-skill-oracle-connector",
+
+  "kafka.api.key": "${file:/secrets.properties:KAFKA_API_KEY}",
+  "kafka.api.secret": "${file:/secrets.properties:KAFKA_API_SECRET}",
+
+  "database.hostname": "<oracle-host>",
+  "database.port": "1521",
+  "database.user": "<oracle-user>",
+  "database.password": "<oracle-password>",
+  "database.dbname": "<service-name-or-sid>",
+  "database.server.name": "<logical-server-name>",
+  "topic.prefix": "<topic-prefix>",
+
+  "database.connection.adapter": "xstream",
+  "database.out.server.name": "dbz_outbound",
+
+  "table.include.list": "<schema>.<table1>,<schema>.<table2>",
+
+  "output.data.format": "JSON_SR",
+  "output.key.format": "JSON_SR",
+
+  "snapshot.mode": "initial",
+
+  "tombstones.on.delete": "true",
+
+  "tasks.max": "1"
+}
+```
+
+**Key Parameters:**
+- `database.dbname`: Oracle service name or SID
+- `database.connection.adapter`: Use `xstream` for XStream
+- `database.out.server.name`: XStream outbound server name (created in Oracle)
+- `topic.prefix`: **REQUIRED** — Controls topic naming
+- `table.include.list`: Comma-separated list of tables (format: `SCHEMA.TABLE` - uppercase)
+- `snapshot.mode`: Same options as PostgreSQL
+
+**Topic Naming:**
+Topic pattern: `<topic.prefix>.<schema>.<table>`
+
+Example: `oracle-cdc.HR.EMPLOYEES`
+
+**Documentation:**
+https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-source/cc-oracle-xstream-source.html
+
+---
+
+## DynamoDB CDC Source
+
+**Connector Class:** `DynamoDbCdcSource`
+
+```json
+{
+  "connector.class": "DynamoDbCdcSource",
+  "name": "cdc-pipeline-skill-dynamodb-connector",
+
+  "kafka.api.key": "${file:/secrets.properties:KAFKA_API_KEY}",
+  "kafka.api.secret": "${file:/secrets.properties:KAFKA_API_SECRET}",
+
+  "aws.access.key.id": "<aws-access-key>",
+  "aws.secret.access.key": "<aws-secret-key>",
+  "aws.dynamodb.region": "<aws-region>",
+
+  "table.include.list": "<table1>,<table2>",
+
+  "kafka.topic": "cdc-pipeline-skill-dynamodb-<table-name>",
+
+  "output.data.format": "JSON_SR",
+  "output.key.format": "JSON_SR",
+
+  "tasks.max": "1"
+}
+```
+
+**Key Parameters:**
+- `aws.access.key.id` / `aws.secret.access.key`: IAM credentials with DynamoDB Streams permissions
+- `aws.dynamodb.region`: AWS region where DynamoDB table is located
+- `table.include.list`: Comma-separated list of DynamoDB table names
+- `kafka.topic`: Topic name pattern (use table name variable)
+
+**Topic Naming:**
+Topic pattern: `<kafka.topic>` (configurable, unlike other connectors)
+
+Example: `cdc-pipeline-skill-dynamodb-users`
+
+**Documentation:**
+https://docs.confluent.io/cloud/current/connectors/cc-amazon-dynamodb-source.html
+
+---
+
+## Configuration Best Practices
+
+### Secrets Management
+
+**Option 1: Use Confluent Secrets (Recommended)**
+```json
+{
+  "database.password": "${file:/path/to/secrets.properties:DB_PASSWORD}",
+  "kafka.api.key": "${file:/path/to/secrets.properties:KAFKA_API_KEY}"
+}
+```
+
+**Option 2: Environment Variables**
+```json
+{
+  "database.password": "${env:DB_PASSWORD}"
+}
+```
+
+### Snapshot Modes
+
+- `initial`: Snapshot existing data on first run, then stream changes (recommended for new connectors)
+- `never`: Skip snapshot, only capture new changes (use when you don't need historical data)
+- `always`: Always snapshot on restart (use for testing, not production)
+
+### Tombstones
+
+Always enable tombstones for proper delete handling:
+```json
+{
+  "tombstones.on.delete": "true"
+}
+```
+
+This produces a null-value record when a row is deleted, which is important for downstream consumers.
+
+### Schema Changes
+
+For production, usually disable schema change events:
+```json
+{
+  "include.schema.changes": "false"
+}
+```
+
+Schema changes (DDL) are captured separately and can create noise in the pipeline.
+
+### Heartbeat
+
+Enable heartbeat to detect stalled connectors:
+```json
+{
+  "heartbeat.interval.ms": "30000",
+  "heartbeat.action.query": "INSERT INTO heartbeat (ts) VALUES (NOW())"
+}
+```
+
+Heartbeat produces a special event every N milliseconds to show the connector is alive.
+
+### Task Parallelism
+
+Most CDC connectors work best with `tasks.max = 1` because:
+- Single-task ensures message ordering per table
+- Database transactions are sequential
+- Parallel tasks can cause out-of-order events
+
+Only increase for very high-throughput scenarios with careful testing.
+
+---
+
+## Validation Checklist
+
+Before deploying a connector configuration:
+
+- [ ] Database prerequisites met (WAL, binlog, CDC enabled, etc.)
+- [ ] Database user has correct permissions
+- [ ] Network connectivity verified
+- [ ] Schema Registry endpoint is correct
+- [ ] API keys are valid and have correct permissions
+- [ ] Table names are correctly formatted (schema.table, case-sensitive for some DBs)
+- [ ] Snapshot mode is appropriate for use case
+- [ ] Tombstones enabled for delete handling
+- [ ] Secrets are properly externalized (not hardcoded)
+
+---
+
+## Testing Connector Configuration
+
+After creating a connector, verify it's working:
+
+```bash
+# Check connector status
+confluent connect cluster describe <connector-id>
+
+# Should show: "status": "RUNNING"
+
+# View topics created
+confluent kafka topic list | grep <connector-name>
+
+# Consume sample messages
+confluent kafka topic consume <topic-name> --from-beginning --max-messages 5
+
+# Check connector tasks
+confluent connect cluster describe <connector-id> --show-tasks
+```
+
+If connector fails, check logs:
+```bash
+confluent connect cluster describe <connector-id> --show-logs
+```

--- a/skills/confluent-cloud-cdc-tableflow/references/database-prerequisites.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/database-prerequisites.md
@@ -160,11 +160,16 @@ CREATE USER '<connector_user>'@'%' IDENTIFIED BY '<password>';
 GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT
   ON *.* TO '<connector_user>'@'%';
 
+-- Grant LOCK TABLES (required for managed MySQL — see note below)
+GRANT LOCK TABLES ON <database>.* TO '<connector_user>'@'%';
+
 -- Grant permissions on specific database/tables
 GRANT SELECT ON <database>.* TO '<connector_user>'@'%';
 
 FLUSH PRIVILEGES;
 ```
+
+**Why LOCK TABLES is needed on managed MySQL:** Debezium's default snapshot behavior tries `FLUSH TABLES WITH READ LOCK` first (a global read lock requiring the `SUPER` or `RELOAD` privilege). On self-managed MySQL where the user has `SUPER`, this works fine. But managed services (RDS, Aurora, Cloud SQL, Azure MySQL) don't grant `SUPER`, so the global lock fails and Debezium falls back to per-table `LOCK TABLES` — which requires the `LOCK TABLES` privilege explicitly. Without it, the connector fails during the initial snapshot with: *"The database user does not have the 'LOCK TABLES' privilege required to obtain a consistent snapshot."*
 
 ### Cloud-Specific Notes
 
@@ -173,16 +178,19 @@ FLUSH PRIVILEGES;
 - Set `binlog_format = ROW` in parameter group
 - Enable automated backups (required for binlog)
 - User needs `mysql.rds_set_configuration` for binlog retention
+- **Grant `LOCK TABLES`** — RDS does not grant `SUPER`, so Debezium needs per-table locks for snapshots
 
 **Google Cloud SQL:**
 - Enable binary logging in flags
 - Set `binlog_format = ROW`
 - Set retention period in days
+- **Grant `LOCK TABLES`** — Cloud SQL restricts `SUPER`, same as RDS
 
 **Azure Database for MySQL:**
 - Enable binary logging in server parameters
 - Set `binlog_format = ROW`
 - Configure binlog retention
+- **Grant `LOCK TABLES`** — Azure restricts `SUPER`, same as RDS
 
 ### Verification
 

--- a/skills/confluent-cloud-cdc-tableflow/references/database-prerequisites.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/database-prerequisites.md
@@ -1,0 +1,491 @@
+# Database Prerequisites for CDC
+
+Each database requires specific configuration to support Change Data Capture. This guide covers the prerequisites for each supported database type.
+
+## PostgreSQL CDC Prerequisites
+
+### Required PostgreSQL Configuration
+
+**WAL Level:**
+```sql
+-- Check current WAL level
+SHOW wal_level;
+
+-- Must be 'logical'
+-- Set in postgresql.conf:
+wal_level = logical
+```
+
+**Replication Slots:**
+```sql
+-- Check max_replication_slots
+SHOW max_replication_slots;
+
+-- Should be at least 1 per connector (recommend 4+)
+-- Set in postgresql.conf:
+max_replication_slots = 4
+```
+
+**WAL Senders:**
+```sql
+-- Check max_wal_senders
+SHOW max_wal_senders;
+
+-- Should be at least 1 per connector (recommend 4+)
+-- Set in postgresql.conf:
+max_wal_senders = 4
+```
+
+**Restart Required:**
+After changing these settings, PostgreSQL must be restarted.
+
+### Required Permissions
+
+The connector user needs these permissions:
+
+```sql
+-- Grant replication privilege
+ALTER USER <connector_user> WITH REPLICATION;
+
+-- Grant permissions on database
+GRANT CONNECT ON DATABASE <database> TO <connector_user>;
+
+-- Grant schema permissions
+GRANT USAGE ON SCHEMA <schema> TO <connector_user>;
+
+-- Grant table permissions
+GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO <connector_user>;
+
+-- Grant permissions for future tables
+ALTER DEFAULT PRIVILEGES IN SCHEMA <schema>
+  GRANT SELECT ON TABLES TO <connector_user>;
+```
+
+### Publication Setup (PostgreSQL 10+)
+
+```sql
+-- Create publication for tables to capture
+CREATE PUBLICATION dbz_publication FOR TABLE table1, table2, table3;
+
+-- Or for all tables in a schema
+CREATE PUBLICATION dbz_publication FOR ALL TABLES;
+```
+
+### Cloud-Specific Notes
+
+**AWS RDS/Aurora:**
+- Set `rds.logical_replication = 1` in parameter group
+- Reboot instance after parameter change
+- Use the master user or create user with `rds_replication` role
+
+**Google Cloud SQL:**
+- Set `cloudsql.logical_decoding = on` in flags
+- Restart instance
+- Grant `cloudsqlsuperuser` role to connector user
+
+**Azure Database for PostgreSQL:**
+- Set `wal_level = logical` in server parameters
+- Set `max_replication_slots >= 4`
+- Restart server
+
+### Verification
+
+```sql
+-- Verify WAL level
+SELECT name, setting FROM pg_settings WHERE name = 'wal_level';
+
+-- Check replication slots
+SELECT * FROM pg_replication_slots;
+
+-- Test publication
+SELECT * FROM pg_publication;
+SELECT * FROM pg_publication_tables WHERE pubname = 'dbz_publication';
+```
+
+**References:**
+- Debezium PostgreSQL: https://debezium.io/documentation/reference/2.4/connectors/postgresql.html#postgresql-in-the-cloud
+- Confluent PostgreSQL CDC V2: https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-debezium/cc-postgresql-cdc-source-v2-debezium.html
+
+---
+
+## MySQL CDC Prerequisites
+
+### Required MySQL Configuration
+
+**Binary Logging:**
+```sql
+-- Check if binary logging is enabled
+SHOW VARIABLES LIKE 'log_bin';
+
+-- Check binlog format (must be ROW)
+SHOW VARIABLES LIKE 'binlog_format';
+
+-- Set in my.cnf or my.ini:
+log_bin = mysql-bin
+binlog_format = ROW
+binlog_row_image = FULL
+```
+
+**GTID Mode (Recommended):**
+```sql
+-- Check GTID status
+SHOW VARIABLES LIKE 'gtid_mode';
+SHOW VARIABLES LIKE 'enforce_gtid_consistency';
+
+-- Enable in my.cnf:
+gtid_mode = ON
+enforce_gtid_consistency = ON
+```
+
+**Binary Log Retention:**
+```sql
+-- Check retention (in seconds)
+SHOW VARIABLES LIKE 'binlog_expire_logs_seconds';
+
+-- Set retention to at least 7 days (604800 seconds)
+-- In my.cnf:
+binlog_expire_logs_seconds = 604800
+```
+
+**Restart Required:**
+After changing these settings, MySQL must be restarted.
+
+### Required Permissions
+
+```sql
+-- Create dedicated CDC user
+CREATE USER '<connector_user>'@'%' IDENTIFIED BY '<password>';
+
+-- Grant replication privileges
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT
+  ON *.* TO '<connector_user>'@'%';
+
+-- Grant permissions on specific database/tables
+GRANT SELECT ON <database>.* TO '<connector_user>'@'%';
+
+FLUSH PRIVILEGES;
+```
+
+### Cloud-Specific Notes
+
+**AWS RDS/Aurora:**
+- Binary logging is enabled by default
+- Set `binlog_format = ROW` in parameter group
+- Enable automated backups (required for binlog)
+- User needs `mysql.rds_set_configuration` for binlog retention
+
+**Google Cloud SQL:**
+- Enable binary logging in flags
+- Set `binlog_format = ROW`
+- Set retention period in days
+
+**Azure Database for MySQL:**
+- Enable binary logging in server parameters
+- Set `binlog_format = ROW`
+- Configure binlog retention
+
+### Verification
+
+```sql
+-- Verify binlog is enabled and ROW format
+SHOW VARIABLES LIKE 'log_bin';
+SHOW VARIABLES LIKE 'binlog_format';
+SHOW VARIABLES LIKE 'binlog_row_image';
+
+-- Check GTID mode
+SHOW VARIABLES LIKE 'gtid_mode';
+
+-- List binary logs
+SHOW BINARY LOGS;
+
+-- Verify user permissions
+SHOW GRANTS FOR '<connector_user>'@'%';
+```
+
+**References:**
+- Debezium MySQL: https://debezium.io/documentation/reference/2.4/connectors/mysql.html
+- Confluent MySQL CDC V2: https://docs.confluent.io/cloud/current/connectors/cc-mysql-cdc-source-v2-debezium/cc-mysql-cdc-source-v2-debezium.html
+
+---
+
+## SQL Server CDC Prerequisites
+
+### Enable CDC on Database
+
+```sql
+-- Check if CDC is enabled on database
+SELECT is_cdc_enabled FROM sys.databases
+WHERE name = '<database_name>';
+
+-- Enable CDC on database
+USE <database_name>;
+EXEC sys.sp_cdc_enable_db;
+```
+
+### Enable CDC on Tables
+
+```sql
+-- Enable CDC for specific table
+USE <database_name>;
+EXEC sys.sp_cdc_enable_table
+  @source_schema = N'dbo',
+  @source_name   = N'<table_name>',
+  @role_name     = NULL,
+  @supports_net_changes = 1;
+
+-- Verify CDC is enabled for table
+SELECT name, is_tracked_by_cdc
+FROM sys.tables
+WHERE name = '<table_name>';
+```
+
+### SQL Server Agent
+
+**Critical:** SQL Server Agent must be running for CDC to work.
+
+```sql
+-- Check SQL Server Agent status (in Management Studio or via xp_servicecontrol)
+EXEC xp_servicecontrol 'QueryState', 'SQLServerAGENT';
+```
+
+### Required Permissions
+
+```sql
+-- Create login and user
+CREATE LOGIN <connector_user> WITH PASSWORD = '<password>';
+USE <database_name>;
+CREATE USER <connector_user> FOR LOGIN <connector_user>;
+
+-- Grant permissions
+GRANT SELECT ON SCHEMA :: dbo TO <connector_user>;
+GRANT VIEW DATABASE STATE TO <connector_user>;
+EXEC sp_addrolemember N'db_datareader', N'<connector_user>';
+
+-- Grant access to CDC tables
+GRANT SELECT ON SCHEMA :: cdc TO <connector_user>;
+```
+
+### Cloud-Specific Notes
+
+**AWS RDS SQL Server:**
+- Use `msdb.dbo.rds_cdc_enable_db` instead of `sys.sp_cdc_enable_db`
+- SQL Server Agent runs automatically
+- Example:
+  ```sql
+  EXEC msdb.dbo.rds_cdc_enable_db '<database_name>';
+  ```
+
+**Azure SQL Database:**
+- CDC is supported on all service tiers
+- SQL Server Agent equivalent runs automatically
+- Use standard CDC procedures
+
+### Verification
+
+```sql
+-- Check database CDC status
+SELECT name, is_cdc_enabled FROM sys.databases;
+
+-- List CDC-enabled tables
+SELECT SCHEMA_NAME(schema_id) + '.' + name AS table_name, is_tracked_by_cdc
+FROM sys.tables
+WHERE is_tracked_by_cdc = 1;
+
+-- View CDC capture instances
+SELECT * FROM cdc.change_tables;
+
+-- Check CDC jobs are running
+EXEC sys.sp_cdc_help_jobs;
+```
+
+**References:**
+- Debezium SQL Server: https://debezium.io/documentation/reference/2.4/connectors/sqlserver.html
+- Confluent SQL Server CDC V2: https://docs.confluent.io/cloud/current/connectors/cc-microsoft-sql-server-cdc-source-v2-debezium/cc-microsoft-sql-server-cdc-source-v2-debezium.html
+
+---
+
+## Oracle CDC Prerequisites
+
+### Archive Log Mode
+
+Oracle must be in ARCHIVELOG mode:
+
+```sql
+-- Check archive log mode
+SELECT log_mode FROM v$database;
+
+-- Enable archive log mode (requires restart)
+SHUTDOWN IMMEDIATE;
+STARTUP MOUNT;
+ALTER DATABASE ARCHIVELOG;
+ALTER DATABASE OPEN;
+```
+
+### Supplemental Logging
+
+```sql
+-- Enable minimal supplemental logging at database level
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
+
+-- Enable identification key logging
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (PRIMARY KEY) COLUMNS;
+
+-- For tables without primary keys, enable all columns
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+
+-- Verify supplemental logging
+SELECT supplemental_log_data_min, supplemental_log_data_pk
+FROM v$database;
+```
+
+### Table-Level Supplemental Logging
+
+```sql
+-- For each table to capture
+ALTER TABLE <schema>.<table> ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+```
+
+### XStream Configuration
+
+For Oracle XStream CDC connector:
+
+```sql
+-- Create XStream admin user
+CREATE USER xstream_admin IDENTIFIED BY <password>;
+GRANT CREATE SESSION TO xstream_admin;
+
+-- Grant XStream privileges
+BEGIN
+  DBMS_XSTREAM_AUTH.GRANT_ADMIN_PRIVILEGE(
+    grantee => 'xstream_admin',
+    privilege_type => 'CAPTURE',
+    grant_select_privileges => TRUE
+  );
+END;
+/
+
+-- Create outbound server
+BEGIN
+  DBMS_XSTREAM_ADM.CREATE_OUTBOUND(
+    server_name => 'dbz_outbound',
+    table_names => '<schema>.<table>',
+    source_database => '<database>'
+  );
+END;
+/
+```
+
+### Required Permissions
+
+```sql
+-- Create connector user
+CREATE USER <connector_user> IDENTIFIED BY <password>;
+
+-- Grant session and basic permissions
+GRANT CREATE SESSION TO <connector_user>;
+GRANT SET CONTAINER TO <connector_user>;
+GRANT SELECT ON V_$DATABASE TO <connector_user>;
+GRANT FLASHBACK ANY TABLE TO <connector_user>;
+
+-- Grant table permissions
+GRANT SELECT ON <schema>.<table> TO <connector_user>;
+```
+
+### Verification
+
+```sql
+-- Check archive log mode
+SELECT log_mode FROM v$database;
+
+-- Verify supplemental logging
+SELECT supplemental_log_data_min, supplemental_log_data_pk, supplemental_log_data_all
+FROM v$database;
+
+-- Check XStream outbound server
+SELECT server_name, capture_name, connect_user, status
+FROM DBA_XSTREAM_OUTBOUND;
+```
+
+**References:**
+- Debezium Oracle: https://debezium.io/documentation/reference/2.4/connectors/oracle.html
+- Confluent Oracle XStream CDC: https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-source/cc-oracle-xstream-source.html
+
+---
+
+## DynamoDB CDC Prerequisites
+
+### DynamoDB Streams
+
+Enable DynamoDB Streams on the table:
+
+```bash
+# Using AWS CLI
+aws dynamodb update-table \
+  --table-name <table-name> \
+  --stream-specification StreamEnabled=true,StreamViewType=NEW_AND_OLD_IMAGES
+```
+
+**Stream View Types:**
+- `NEW_IMAGE`: Only new item after modification
+- `OLD_IMAGE`: Only old item before modification
+- `NEW_AND_OLD_IMAGES`: Both (recommended for CDC)
+- `KEYS_ONLY`: Only key attributes
+
+**Recommendation:** Use `NEW_AND_OLD_IMAGES` for full CDC capabilities.
+
+### IAM Permissions
+
+Create IAM user or role with these permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:DescribeStream",
+        "dynamodb:GetRecords",
+        "dynamodb:GetShardIterator",
+        "dynamodb:ListStreams",
+        "dynamodb:ListTables"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:*:table/<table-name>",
+        "arn:aws:dynamodb:*:*:table/<table-name>/stream/*"
+      ]
+    }
+  ]
+}
+```
+
+### Verification
+
+```bash
+# Check if streams are enabled
+aws dynamodb describe-table --table-name <table-name> \
+  | jq '.Table.StreamSpecification'
+
+# List streams for table
+aws dynamodb list-streams --table-name <table-name>
+```
+
+**References:**
+- Debezium DynamoDB: https://debezium.io/documentation/reference/2.4/connectors/dynamodb.html
+- Confluent DynamoDB CDC: https://docs.confluent.io/cloud/current/connectors/cc-amazon-dynamodb-source.html
+- AWS DynamoDB Streams: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
+
+---
+
+## General Checklist
+
+Before setting up any CDC connector, verify:
+
+- [ ] Database is configured for CDC (WAL, binlog, archive log, streams)
+- [ ] Database user has appropriate permissions
+- [ ] Network connectivity from Confluent Cloud to database
+- [ ] Firewall rules allow connection
+- [ ] Schema Registry is enabled in Confluent Cloud
+- [ ] Sufficient database resources for CDC overhead
+- [ ] Monitoring in place for replication lag

--- a/skills/confluent-cloud-cdc-tableflow/references/flink-sql-patterns.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/flink-sql-patterns.md
@@ -37,7 +37,9 @@ Debezium uses specific logical types that map to Flink types differently than yo
 | `io.debezium.time.Date` | `INT` | Days since epoch | Use as-is or convert |
 | `io.debezium.time.MicroTime` | `BIGINT` | Microseconds since midnight | Use as-is or convert |
 | Regular `INT`, `BIGINT`, `STRING`, etc. | Direct mapping | Standard types | No conversion needed |
-| `DECIMAL` / `NUMERIC` | `DECIMAL` or `BYTES` | Precision-dependent | Check schema |
+| `DECIMAL` / `NUMERIC` | `STRING` (with `decimal.handling.mode=string`) or `BYTES` (default) | DECIMAL or STRING | Set `decimal.handling.mode: string` on the connector — without it, DECIMAL arrives as raw BYTES that Flink cannot cast. With `string` mode, values arrive as human-readable strings like `"1299.99"` |
+| `INTERVAL` (PG/Oracle) | `STRING` (with `interval.handling.mode=string`) or `INT64` (default, lossy micros) | STRING | Set `interval.handling.mode: string` on the connector for lossless ISO 8601 format |
+| Binary (`BYTEA`, `BLOB`, etc.) | `STRING` (with `binary.handling.mode=base64`) or `BYTES` (default) | STRING | Set `binary.handling.mode: base64` on the connector for JSON-safe base64 encoding |
 
 ---
 
@@ -227,7 +229,23 @@ Use `mcp__confluent__create-flink-statement` with:
 - **Problem:** `TO_TIMESTAMP_LTZ()` returns `TIMESTAMP_LTZ(3)`, incompatible with `TIMESTAMP(3)`.
 - **Solution:** Define target columns as `TIMESTAMP_LTZ(3)`.
 
-**Pitfall 5: CDC source table not in SHOW TABLES**
+**Pitfall 5: DECIMAL columns appear as garbled BYTES**
+- **Problem:** DECIMAL/NUMERIC columns show as raw bytes (e.g., `"N\u001f"` instead of `"199.99"`). Flink cannot CAST VARBINARY to DECIMAL.
+- **Solution:** This must be fixed at the connector level, not in Flink. Set `"decimal.handling.mode": "string"` in the Debezium connector config. This outputs decimal values as human-readable strings which Flink can handle directly.
+
+**Pitfall 6: INTERVAL columns produce lossy microsecond values**
+- **Problem:** PostgreSQL `INTERVAL` or Oracle `INTERVAL YEAR TO MONTH` columns arrive as INT64 microseconds, approximating months as 30 days and years as 365.25 days.
+- **Solution:** Set `"interval.handling.mode": "string"` on the connector. Values arrive as ISO 8601 strings (e.g., `P1Y2M3DT4H5M6.78S`).
+
+**Pitfall 7: Binary columns break JSON serialization**
+- **Problem:** BYTEA, VARBINARY, BLOB, or RAW columns serialized as raw bytes produce garbled or inconsistent JSON output.
+- **Solution:** Set `"binary.handling.mode": "base64"` on the connector. Values arrive as base64-encoded strings.
+
+**Pitfall 8: Oracle NUMBER without precision produces struct, not scalar**
+- **Problem:** Oracle `NUMBER` (no precision/scale) and `FLOAT` columns are serialized as `VariableScaleDecimal` — a struct of `{scale: INT32, value: BYTES}`, not a simple value. This breaks differently than regular DECIMAL bytes.
+- **Solution:** Set `"decimal.handling.mode": "string"` on the connector. Converts to human-readable string values.
+
+**Pitfall 9: CDC source table not in SHOW TABLES**
 - **Problem:** Connector just created, table not visible yet.
 - **Solution:** Wait 2-5 minutes for connector provisioning. Verify schemas exist via `mcp__confluent__list-schemas`.
 

--- a/skills/confluent-cloud-cdc-tableflow/references/flink-sql-patterns.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/flink-sql-patterns.md
@@ -1,0 +1,240 @@
+# Flink SQL Patterns for Debezium CDC in Confluent Cloud
+
+This guide covers Flink SQL patterns for working with Debezium CDC events in Confluent Cloud Flink. In Confluent Cloud, Flink is deeply integrated with Schema Registry and Kafka -- source tables from CDC connectors are auto-discovered, and no explicit connector or format properties are needed in CREATE TABLE statements.
+
+---
+
+## Key Principle: Auto-Discovery of CDC Source Tables
+
+When a Debezium CDC connector creates topics with schemas registered in Schema Registry, Confluent Cloud Flink **automatically discovers** those topics as Flink tables. You do NOT need to create source tables manually.
+
+For example, if a CDC connector with `topic.prefix = "postgres-cdc"` captures the `public.customers` table, the topic `postgres-cdc.public.customers` automatically appears as a Flink table:
+
+```sql
+-- This table already exists -- no CREATE TABLE needed
+-- Reference it with backtick-quoting due to dots in the name:
+SELECT * FROM `postgres-cdc.public.customers` LIMIT 5;
+```
+
+Verify auto-discovered tables with:
+
+```sql
+SHOW TABLES;
+```
+
+If the CDC source table does not appear, the connector may not have produced data yet. Wait 2-5 minutes for the connector to fully provision and produce its initial snapshot.
+
+---
+
+## Debezium Type Mappings
+
+Debezium uses specific logical types that map to Flink types differently than you might expect. Understanding these is critical to avoid type mismatches.
+
+| Debezium Logical Type | Flink Column Type | Meaning | Conversion |
+|---|---|---|---|
+| `io.debezium.time.MicroTimestamp` | `BIGINT` | Microseconds since epoch | `TO_TIMESTAMP_LTZ(col / 1000, 3)` |
+| `io.debezium.time.Timestamp` | `BIGINT` | Milliseconds since epoch | `TO_TIMESTAMP_LTZ(col, 3)` |
+| `io.debezium.time.Date` | `INT` | Days since epoch | Use as-is or convert |
+| `io.debezium.time.MicroTime` | `BIGINT` | Microseconds since midnight | Use as-is or convert |
+| Regular `INT`, `BIGINT`, `STRING`, etc. | Direct mapping | Standard types | No conversion needed |
+| `DECIMAL` / `NUMERIC` | `DECIMAL` or `BYTES` | Precision-dependent | Check schema |
+
+---
+
+## Pattern 1: Create Target Table (Minimal WITH Clause)
+
+Target tables are the only tables you need to CREATE. They use a minimal WITH clause -- no connector, format, bootstrap server, or Schema Registry properties are needed.
+
+```sql
+CREATE TABLE `target_customers` (
+  `id` INT NOT NULL,
+  `name` STRING,
+  `email` STRING,
+  `created_at` TIMESTAMP_LTZ(3),
+  PRIMARY KEY (`id`) NOT ENFORCED
+) WITH (
+  'changelog.mode' = 'upsert'
+);
+```
+
+**Key Points:**
+- Only `'changelog.mode' = 'upsert'` is needed in the WITH clause for CDC use cases
+- Do NOT add `'connector'`, `'value.format'`, `'properties.bootstrap.servers'`, or Schema Registry URL properties -- these are not supported in Confluent Cloud Flink and will cause errors
+- Use `TIMESTAMP_LTZ(3)` (not `TIMESTAMP(3)`) for timestamp columns converted from Debezium MicroTimestamp or Timestamp types
+- Define `PRIMARY KEY (...) NOT ENFORCED` to maintain upsert semantics for CDC
+
+---
+
+## Pattern 2: INSERT Statement (CDC Envelope Decoded Automatically)
+
+Confluent Cloud Flink recognizes CDC changelog tables natively. You do NOT need to reference `after.*` fields or filter by `op`. Flink handles Debezium envelope decoding and CDC semantics (inserts, updates, deletes) automatically.
+
+```sql
+INSERT INTO `target_customers`
+SELECT
+  `id`,
+  `name`,
+  `email`,
+  TO_TIMESTAMP_LTZ(`created_at` / 1000, 3)
+FROM `postgres-cdc.public.customers`;
+```
+
+**Key Points:**
+- Reference columns directly by name (e.g., `id`, `name`) -- not as `after.id` or `after.name`
+- Flink automatically interprets the Debezium changelog stream, handling inserts, updates, and deletes
+- Apply timestamp conversions as needed based on the Debezium type mappings above
+- No `WHERE op IN ('c', 'u', 'r')` filter needed -- CDC semantics are handled natively
+
+---
+
+## Pattern 3: Multi-Table Pipeline
+
+When capturing multiple tables, create a target table and INSERT statement for each. Each INSERT runs as a separate continuous Flink statement.
+
+```sql
+-- Target tables (source tables are auto-discovered)
+CREATE TABLE `target_customers` (
+  `id` INT NOT NULL,
+  `name` STRING,
+  `email` STRING,
+  `created_at` TIMESTAMP_LTZ(3),
+  PRIMARY KEY (`id`) NOT ENFORCED
+) WITH ('changelog.mode' = 'upsert');
+
+CREATE TABLE `target_orders` (
+  `order_id` BIGINT NOT NULL,
+  `customer_id` INT,
+  `amount` DECIMAL(10, 2),
+  `order_date` TIMESTAMP_LTZ(3),
+  PRIMARY KEY (`order_id`) NOT ENFORCED
+) WITH ('changelog.mode' = 'upsert');
+
+-- INSERT statements (each submitted as a separate Flink statement)
+INSERT INTO `target_customers`
+SELECT `id`, `name`, `email`, TO_TIMESTAMP_LTZ(`created_at` / 1000, 3)
+FROM `postgres-cdc.public.customers`;
+
+INSERT INTO `target_orders`
+SELECT `order_id`, `customer_id`, `amount`, TO_TIMESTAMP_LTZ(`order_date` / 1000, 3)
+FROM `postgres-cdc.public.orders`;
+```
+
+**Important:** Each INSERT must be submitted as a separate Flink statement via MCP.
+
+---
+
+## Pattern 4: Filtering and Transformation
+
+**Filter by column value:**
+```sql
+INSERT INTO `target_active_customers`
+SELECT `id`, `name`, `email`, TO_TIMESTAMP_LTZ(`created_at` / 1000, 3)
+FROM `postgres-cdc.public.customers`
+WHERE `status` = 'active';
+```
+
+**Add computed columns:**
+```sql
+INSERT INTO `target_customers_enriched`
+SELECT
+  `id`, `name`, `email`,
+  TO_TIMESTAMP_LTZ(`created_at` / 1000, 3),
+  CURRENT_TIMESTAMP AS `processed_at`,
+  'flink-cdc-pipeline' AS `source_system`
+FROM `postgres-cdc.public.customers`;
+```
+
+**Join with reference data:**
+```sql
+INSERT INTO `target_orders_enriched`
+SELECT o.`order_id`, o.`customer_id`, o.`region_id`, r.`region_name`, o.`amount`
+FROM `postgres-cdc.public.orders` o
+LEFT JOIN `dim_regions` r ON o.`region_id` = r.`region_id`;
+```
+
+---
+
+## Pattern 5: Schema Evolution
+
+When database schemas change, update Flink tables:
+
+```sql
+-- 1. Stop the INSERT statement (via MCP: delete-flink-statements)
+-- 2. Drop and recreate target table with new columns
+DROP TABLE `target_customers`;
+CREATE TABLE `target_customers` (
+  `id` INT NOT NULL,
+  `name` STRING,
+  `email` STRING,
+  `phone` STRING,       -- New column
+  `created_at` TIMESTAMP_LTZ(3),
+  PRIMARY KEY (`id`) NOT ENFORCED
+) WITH ('changelog.mode' = 'upsert');
+
+-- 3. Recreate INSERT with new column
+INSERT INTO `target_customers`
+SELECT `id`, `name`, `email`, `phone`, TO_TIMESTAMP_LTZ(`created_at` / 1000, 3)
+FROM `postgres-cdc.public.customers`;
+```
+
+---
+
+## Statement Management via MCP
+
+### Creating a Flink Statement
+
+Use `mcp__confluent__create-flink-statement` with:
+
+| Parameter | Description | Example |
+|---|---|---|
+| `statement` | The SQL text | `CREATE TABLE ...` or `INSERT INTO ...` |
+| `statementName` | Lowercase kebab-case name | `cdc-create-target-customers` |
+| `environmentId` | The Confluent environment ID | `env-abc123` |
+| `computePoolId` | The Flink compute pool ID | `lfcp-xyz789` |
+| `catalogName` | Usually the environment display name | `my-environment` |
+| `databaseName` | The Kafka cluster display name | `dedicated_cluster` |
+
+### Workflow
+
+1. `SHOW TABLES` → verify CDC source table is auto-discovered
+2. `CREATE TABLE` → create target table with upsert mode
+3. `INSERT INTO` → start continuous decode pipeline
+4. `read-flink-statement` → verify INSERT is running (no error)
+
+### Other MCP Operations
+
+- **List:** `mcp__confluent__list-flink-statements`
+- **Read/results:** `mcp__confluent__read-flink-statement`
+- **Delete:** `mcp__confluent__delete-flink-statements`
+
+---
+
+## Common Pitfalls and Solutions
+
+**Pitfall 1: Using explicit connector/format properties**
+- **Problem:** `'value.format' = 'avro-confluent'` or `'connector' = 'kafka'` in CREATE TABLE
+- **Solution:** Remove all format/connector/bootstrap/SR properties. Cloud Flink handles this automatically.
+
+**Pitfall 2: Creating explicit source tables for CDC topics**
+- **Problem:** Manually creating source tables with `before`/`after` ROW types
+- **Solution:** CDC source tables are auto-discovered. Just reference them directly.
+
+**Pitfall 3: Type mismatch on timestamp columns**
+- **Problem:** Debezium MicroTimestamp is BIGINT, not TIMESTAMP. INSERT fails with type error.
+- **Solution:** Use `TO_TIMESTAMP_LTZ(col / 1000, 3)` and `TIMESTAMP_LTZ(3)` in target.
+
+**Pitfall 4: Using TIMESTAMP(3) instead of TIMESTAMP_LTZ(3)**
+- **Problem:** `TO_TIMESTAMP_LTZ()` returns `TIMESTAMP_LTZ(3)`, incompatible with `TIMESTAMP(3)`.
+- **Solution:** Define target columns as `TIMESTAMP_LTZ(3)`.
+
+**Pitfall 5: CDC source table not in SHOW TABLES**
+- **Problem:** Connector just created, table not visible yet.
+- **Solution:** Wait 2-5 minutes for connector provisioning. Verify schemas exist via `mcp__confluent__list-schemas`.
+
+---
+
+## Resources
+
+- Confluent Cloud Flink SQL Reference: https://docs.confluent.io/cloud/current/flink/reference/overview.html
+- Confluent Cloud Flink CREATE TABLE: https://docs.confluent.io/cloud/current/flink/reference/statements/create-table.html
+- Debezium CDC Connectors: https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-debezium.html

--- a/skills/confluent-cloud-cdc-tableflow/references/troubleshooting.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/troubleshooting.md
@@ -1,0 +1,314 @@
+# Troubleshooting Guide: CDC to Tableflow Pipeline
+
+This guide covers common issues when setting up and running CDC pipelines with Debezium, Flink, and Tableflow on Confluent Cloud.
+
+## Table of Contents
+
+1. [MCP Server Issues](#mcp-server-issues)
+2. [Connector Issues](#connector-issues)
+3. [Flink Issues](#flink-issues)
+4. [Tableflow Issues](#tableflow-issues)
+5. [Schema Registry Issues](#schema-registry-issues)
+6. [Performance Issues](#performance-issues)
+7. [Data Quality Issues](#data-quality-issues)
+
+---
+
+## MCP Server Issues
+
+### MCP Cluster Targeting
+
+**Problem:** MCP operations (`consume-messages`, `list-topics`, `create-tableflow-topic`) target the wrong Kafka cluster.
+
+**Cause:** The MCP server's `BOOTSTRAP_SERVERS` and `KAFKA_API_KEY` in the MCP config (`~/.config/claude/mcp.json`) determine which cluster it connects to for Kafka operations.
+
+**Diagnosis:** Run `mcp__confluent__list-topics` and check if the expected topics appear. If you see topics from a different cluster, the MCP config points to the wrong cluster.
+
+**Solution:** Update the MCP config to set `BOOTSTRAP_SERVERS`, `KAFKA_API_KEY`, and `KAFKA_API_SECRET` for the target cluster. Then reconnect MCP with `/mcp`.
+
+### MCP Tableflow create-topic Doesn't Accept Cluster/Environment ID
+
+**Problem:** `mcp__confluent__create-tableflow-topic` returns "topic not found" even though the topic exists on the target cluster.
+
+**Cause:** The MCP tool doesn't have cluster/environment ID parameters and defaults based on the MCP server's bootstrap config.
+
+**Solution:** Either:
+1. Update MCP config to point to the correct cluster, reconnect with `/mcp`, then retry
+2. Enable Tableflow through the Confluent Cloud UI: Environment → Cluster → Topics → topic → Tableflow tab
+
+### MCP read-connector Doesn't Show Status/Errors
+
+**Problem:** Can't see if a connector is RUNNING, FAILED, or PROVISIONING via MCP.
+
+**Cause:** The MCP `read-connector` tool returns config and tasks but not explicit status or error messages.
+
+**Diagnosis:**
+- `tasks: []` → Still provisioning (wait 2-5 minutes)
+- `tasks: [{...}]` → Tasks assigned, connector is running
+- Check `mcp__confluent__list-schemas(subjectPrefix)` → If schemas appear, connector is producing data
+
+**Workaround:** Use the Confluent Cloud UI for detailed connector status and error logs.
+
+---
+
+## Connector Issues
+
+### Missing `topic.prefix`
+
+**Symptom:** Connector creation fails with "topic.prefix is required".
+
+**Solution:** Add `"topic.prefix": "<prefix>"` to connector config. This is a REQUIRED field for all CDC V2 connectors. It controls topic naming: `{topic.prefix}.{schema}.{table}`.
+
+### Managed Connector Provisioning Delay
+
+**Symptom:** Connector shows no tasks (`"tasks": []`) after creation.
+
+**Cause:** Managed connectors on Confluent Cloud take 2-5 minutes to provision.
+
+**Solution:** Poll connector status every 30-60 seconds using `mcp__confluent__read-connector`. Tasks will appear once provisioning completes. Only investigate failures if tasks don't appear after 5 minutes.
+
+### Connector Fails to Start
+
+**Symptom:** Connector status shows `FAILED` immediately after creation.
+
+**Common Causes:**
+
+1. **Database connectivity issues**
+
+   Look for:
+   - `Connection refused` → Network/firewall blocking access
+   - `Authentication failed` → Wrong username/password
+   - `Database not found` → Wrong database name
+
+   **Solution:**
+   - Verify database hostname, port, and credentials
+   - Ensure firewall allows Confluent Cloud IP ranges
+   - For cloud databases (RDS, Cloud SQL), check security groups
+
+2. **Database CDC not properly configured**
+
+   **PostgreSQL:**
+   ```sql
+   SHOW wal_level;  -- Must be 'logical'
+   SHOW max_replication_slots;  -- Must be > 0
+   ```
+
+   **MySQL:**
+   ```sql
+   SHOW VARIABLES LIKE 'log_bin';  -- Must be ON
+   SHOW VARIABLES LIKE 'binlog_format';  -- Must be ROW
+   ```
+
+   **SQL Server:**
+   ```sql
+   SELECT is_cdc_enabled FROM sys.databases WHERE name = '<db>';
+   SELECT name, is_tracked_by_cdc FROM sys.tables;
+   ```
+
+   **Solution:** Follow database prerequisites in `references/database-prerequisites.md`
+
+3. **Schema Registry connection issues**
+
+   Error: `Failed to connect to Schema Registry`
+
+   **Solution:** Verify Schema Registry is enabled for the environment
+
+4. **Invalid configuration**
+
+   Error: `Invalid configuration` or `Missing required property`
+
+   **Solution:** Check connector class name, verify all required fields, ensure table names use `schema.table` format
+
+### Connector Runs but No Messages
+
+**Symptom:** Connector has tasks assigned but no topics/schemas appear.
+
+**Diagnosis with MCP:**
+```
+mcp__confluent__list-schemas(subjectPrefix: "<topic-prefix>")
+mcp__confluent__search-topics-by-name(topicName: "<topic-prefix>")
+```
+
+**Common Causes:**
+1. Initial snapshot still in progress (wait a few more minutes)
+2. `table.include.list` filter excludes all tables (check case sensitivity)
+3. `snapshot.mode = "never"` and no recent database changes
+
+---
+
+## Flink Issues
+
+### Invalid Format Specifier in Cloud Flink
+
+**Symptom:** CREATE TABLE fails with "Unsupported format: avro-confluent".
+
+**Cause:** Confluent Cloud Flink handles formats automatically. Explicit format specs like `'value.format' = 'avro-confluent'` are NOT supported.
+
+**Solution:** Remove ALL format, connector, bootstrap, and Schema Registry properties from CREATE TABLE statements. Only use `'changelog.mode' = 'upsert'` in the WITH clause.
+
+### Type Mismatch on Timestamp Columns
+
+**Symptom:** INSERT fails with "Incompatible types for sink column 'created_at'". Query schema shows BIGINT but sink expects TIMESTAMP.
+
+**Cause:** Debezium uses `io.debezium.time.MicroTimestamp` which maps to BIGINT (microseconds since epoch).
+
+**Solution:**
+1. Define target column as `TIMESTAMP_LTZ(3)` (not `TIMESTAMP(3)`)
+2. Convert in INSERT: `TO_TIMESTAMP_LTZ(col / 1000, 3)` for MicroTimestamp, `TO_TIMESTAMP_LTZ(col, 3)` for Timestamp
+
+### CDC Source Table Not Appearing in SHOW TABLES
+
+**Symptom:** `SHOW TABLES` doesn't list the CDC topic table after connector creation.
+
+**Cause:** The CDC connector hasn't produced data yet (still provisioning or doing initial snapshot).
+
+**Solution:**
+1. Verify connector has tasks: `mcp__confluent__read-connector`
+2. Verify schemas exist: `mcp__confluent__list-schemas(subjectPrefix: "<topic-prefix>")`
+3. Wait 2-5 minutes, then retry SHOW TABLES
+4. Ensure `databaseName` in the Flink statement matches the cluster display name where the topic exists
+
+### Flink Statement Fails to Create
+
+**Common Errors:**
+
+1. **Syntax error** (`SQL parse failed`)
+   - Check Confluent Cloud Flink SQL syntax
+   - Ensure proper backtick-quoting for table/column names with special chars
+
+2. **Table does not exist**
+   - CDC source table not yet auto-discovered
+   - Wrong `catalogName` or `databaseName` in MCP statement creation
+   - Topic on a private cluster without network access
+
+3. **Statement name invalid**
+   - Must be lowercase kebab-case: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`
+   - Max 100 characters
+
+### Flink INSERT Runs but No Data Output
+
+**Diagnosis with MCP:**
+```
+mcp__confluent__consume-messages(topicNames: ["<target-topic>"], value: {useSchemaRegistry: true})
+```
+
+Note: Consumer starts at latest offset. If snapshot already completed, insert a new row in the database to verify.
+
+**Common Causes:**
+1. WHERE clause filters all records
+2. Schema mismatch between source and target (check column types)
+3. Source table not receiving data (debug connector first)
+
+### Flink Advisory Warnings (Can Be Ignored)
+
+These warnings appear on INSERT statements but don't prevent execution:
+- "Primary key does not match upsert key" — Expected for CDC decode patterns
+- "Highly state-intensive operators without TTL" — Set TTL if needed for production
+
+---
+
+## Tableflow Issues
+
+**Important:** Tableflow is a **native topic feature** on Confluent Cloud, NOT a sink connector. It is enabled per-topic and materializes data as Iceberg or Delta tables.
+
+**Storage options:**
+- **Managed** — Confluent manages the S3 storage
+- **BYOB (Bring Your Own Bucket)** — User provides S3 bucket with Provider Integration
+
+**Requirement:** Tableflow requires a **Dedicated** cluster. Basic and Standard clusters do not support Tableflow.
+
+### Tableflow Topic Fails to Activate
+
+**Symptom:** Status stays `FAILED` after enabling.
+
+**Common Causes:**
+
+1. **Topic format is wrong** — Tableflow requires a plain format (JSON_SR or Avro), NOT Debezium envelope. Ensure Flink decodes the envelope before writing to the target topic.
+
+2. **Storage credentials invalid (BYOB only)** — Check Provider Integration and IAM permissions.
+
+3. **Cluster type** — Must be a Dedicated cluster.
+
+### Tableflow Not Writing Files
+
+**Symptom:** Tableflow is active but no files appear.
+
+**Causes:**
+1. Not enough data to trigger flush (wait longer or insert more data)
+2. Storage path doesn't exist (BYOB only)
+
+### MCP Tableflow Creation Fails
+
+**Symptom:** `mcp__confluent__create-tableflow-topic` returns "topic not found".
+
+**Cause:** MCP targets the wrong cluster (see MCP Server Issues above).
+
+**Solution:** Update MCP config to point to the dedicated cluster, or use the Confluent Cloud UI.
+
+---
+
+## Schema Registry Issues
+
+### Schema Not Registered
+
+**Diagnosis with MCP:**
+```
+mcp__confluent__list-schemas(subjectPrefix: "<topic-prefix>")
+```
+
+**Solutions:**
+1. Wait for connector/Flink to produce first message (auto-registers schema)
+2. Check subject naming: `<topic-name>-value` and `<topic-name>-key`
+3. Schema compatibility violation — add optional fields, don't remove required ones
+
+### Schema Evolution
+
+When database schemas change:
+1. Stop Flink INSERT statement (`mcp__confluent__delete-flink-statements`)
+2. Drop and recreate target table with new schema
+3. Recreate INSERT statement
+4. Verify new data flows correctly
+
+---
+
+## Performance Issues
+
+### High Latency
+
+Check latency at each stage:
+1. **Connector lag** — `mcp__confluent__read-connector` (check if tasks are healthy)
+2. **Flink processing** — `mcp__confluent__read-flink-statement` (check for backpressure)
+3. **Tableflow lag** — `mcp__confluent__read-tableflow-topic` (check status)
+
+**Solutions:**
+- Increase Flink compute pool CFU
+- Optimize connector config (disable schema changes, adjust batch size)
+- Check for data skew (hotkey issues)
+
+---
+
+## Data Quality Issues
+
+### Duplicate Records
+
+**Causes:**
+1. `snapshot.mode = 'always'` → Use `'initial'` instead
+2. Flink restart replays records → Ensure target table has PRIMARY KEY
+
+### Missing Records
+
+**Diagnosis:**
+1. Check schemas exist for both source and target topics
+2. Verify Flink INSERT is running
+3. Check for overly restrictive WHERE clauses
+
+---
+
+## Getting Help
+
+- **Confluent Support:** https://support.confluent.io/
+- **Confluent Cloud Troubleshooting:** https://docs.confluent.io/cloud/current/troubleshooting/index.html
+- **Debezium Troubleshooting:** https://debezium.io/documentation/reference/stable/operations/index.html
+- **Flink SQL Debugging:** https://docs.confluent.io/cloud/current/flink/troubleshooting.html
+- **Community Forum:** https://forum.confluent.io/
+- **Community Slack:** https://confluentcommunity.slack.com/

--- a/skills/confluent-cloud-cdc-tableflow/references/troubleshooting.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/troubleshooting.md
@@ -119,6 +119,20 @@ This guide covers common issues when setting up and running CDC pipelines with D
 
    **Solution:** Check connector class name, verify all required fields, ensure table names use `schema.table` format
 
+### MySQL Connector Fails: "LOCK TABLES privilege required"
+
+**Symptom:** Connector fails during initial snapshot with: *"The database user does not have the 'LOCK TABLES' privilege required to obtain a consistent snapshot by preventing concurrent writes to tables."*
+
+**Cause:** This happens on all managed MySQL services (AWS RDS/Aurora, Google Cloud SQL, Azure Database for MySQL). Debezium first tries `FLUSH TABLES WITH READ LOCK` (requires `SUPER`), but managed services don't grant `SUPER`. Debezium then falls back to per-table `LOCK TABLES`, which requires an explicit `LOCK TABLES` grant. On self-managed MySQL where the user has `SUPER`, this error doesn't occur because the global lock succeeds.
+
+**Solution:**
+```sql
+GRANT LOCK TABLES ON <database>.* TO '<connector_user>'@'%';
+FLUSH PRIVILEGES;
+```
+
+Then restart or recreate the connector.
+
 ### Connector Runs but No Messages
 
 **Symptom:** Connector has tasks assigned but no topics/schemas appear.
@@ -261,6 +275,22 @@ mcp__confluent__list-schemas(subjectPrefix: "<topic-prefix>")
 2. Check subject naming: `<topic-name>-value` and `<topic-name>-key`
 3. Schema compatibility violation — add optional fields, don't remove required ones
 
+### Stale Schema IDs After Deleting and Recreating Schemas
+
+**Symptom:** After deleting schemas and recreating a CDC connector, Flink goes DEGRADED with errors like `"Schema ID 100001 not found"` or `"Could not find schema for subject"`.
+
+**Cause:** Old messages still on the CDC source topics reference schema IDs that were deleted from Schema Registry. When Flink tries to deserialize these messages, it fails because the schema IDs no longer exist.
+
+**Solution:** When doing a clean reset of a CDC pipeline, you must delete resources in this order:
+1. Delete the Flink INSERT statements
+2. Delete the CDC connector
+3. Delete the CDC source topics (not just schemas) — topics like `{topic.prefix}.{schema}.{table}` and any heartbeat topics
+4. Hard-delete all associated schemas from Schema Registry (both `-key` and `-value` subjects)
+5. Drop the replication slot in PostgreSQL: `SELECT pg_drop_replication_slot('<slot_name>');`
+6. Recreate the connector fresh — it will create new topics, register new schemas, and do a clean initial snapshot
+
+**Important:** Simply deleting schemas without deleting the topics does NOT work. The old messages with stale schema IDs remain on the topics and will cause Flink failures.
+
 ### Schema Evolution
 
 When database schemas change:
@@ -288,6 +318,40 @@ Check latency at each stage:
 ---
 
 ## Data Quality Issues
+
+### DECIMAL/NUMERIC Columns Show Garbled Data
+
+**Symptom:** Price or other DECIMAL columns appear as garbled bytes (e.g., `"N\u001f"` instead of `"199.99"`) in Flink output or consumed messages.
+
+**Cause:** By default, Debezium serializes PostgreSQL DECIMAL/NUMERIC columns as raw bytes (Java BigDecimal unscaled value). This is the default `decimal.handling.mode = precise` behavior.
+
+**Solution:** Add `"decimal.handling.mode": "string"` to the Debezium connector config. This outputs human-readable decimal values like `"1299.99"`. This must be fixed at the connector level — Flink cannot CAST VARBINARY to DECIMAL, so there is no workaround in Flink SQL.
+
+**Note:** After changing this setting, you need to recreate the connector. If existing messages on the topic already have bytes-encoded decimals, follow the "Stale Schema IDs" cleanup procedure above for a clean reset.
+
+### INTERVAL Columns Produce Wrong Values
+
+**Symptom:** PostgreSQL `INTERVAL` or Oracle `INTERVAL YEAR TO MONTH` / `INTERVAL DAY TO SECOND` columns produce large integer values instead of human-readable intervals.
+
+**Cause:** Default `interval.handling.mode = numeric` approximates intervals as microseconds, using lossy conversions (1 month = 30 days, 1 year = 365.25 days). An interval of `1 year` becomes `31557600000000` microseconds.
+
+**Solution:** Add `"interval.handling.mode": "string"` to the connector config. Outputs ISO 8601 format like `P1Y2M3DT4H5M6.78S`.
+
+### Binary Columns Produce Garbled JSON
+
+**Symptom:** BYTEA (PostgreSQL), VARBINARY/BLOB (MySQL), BINARY/IMAGE (SQL Server), or RAW/BLOB (Oracle) columns produce garbled or inconsistent output in consumed messages.
+
+**Cause:** Default `binary.handling.mode = bytes` produces raw byte arrays that break JSON serialization.
+
+**Solution:** Add `"binary.handling.mode": "base64"` to the connector config. Outputs base64-encoded strings that are JSON-safe.
+
+### Oracle NUMBER Without Precision Produces Struct
+
+**Symptom:** Oracle `NUMBER` (no precision/scale) or `FLOAT` columns produce a nested struct instead of a simple value, breaking Flink schemas.
+
+**Cause:** Debezium serializes these as `VariableScaleDecimal` — a struct of `{scale: INT32, value: BYTES}` — because the precision is unknown at schema time.
+
+**Solution:** Add `"decimal.handling.mode": "string"` to the connector config. Converts all numeric types to human-readable strings.
 
 ### Duplicate Records
 


### PR DESCRIPTION
## Description

Adds a new skill for setting up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration (Iceberg/Delta Lake).

### Supported Databases
- PostgreSQL CDC Source V2
- MySQL CDC Source V2
- SQL Server CDC Source V2
- Oracle XStream CDC Source
- DynamoDB CDC Source

### Skill Structure
- `SKILL.md` — Main skill definition with 5 workflow phases (MCP validation, discovery, planning, execution, verification)
- `evals/evals.json` — 7 evaluation test cases covering all supported databases and troubleshooting
- `references/` — 4 reference docs (connector configs, database prerequisites, Flink SQL patterns, troubleshooting)

### Key Features
- Prefers Confluent MCP Server tools with CLI fallback
- Auto-reads MCP `.env` file for environment/cluster defaults
- Handles Debezium type conversions in Flink SQL
- Supports both managed and BYOB Tableflow storage

## Skill Quality Checklist

- [ ] Skill name uses [gerund form](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#naming-conventions) (e.g., `creating-connectors`, not `create-connector`)
- [x] Skill [description is optimized](https://agentskills.io/skill-creation/optimizing-descriptions) for accurate triggering
- [x] Uses concrete examples; avoids verbose paragraphs
- [x] Feedback loops like unit tests are built-in to enable agent iteration

## Testing

- [ ] Evals pass at 90%+ threshold

## Review

- [ ] SME reviewer identified:
- [ ] DTX/DevRel reviewer assigned

## Additional Context

Pipeline flow: **Database → Debezium CDC Connector → Kafka + Schema Registry → Flink (decode & transform) → Tableflow → Iceberg/Delta Tables**

🤖 Generated with [Claude Code](https://claude.com/claude-code)