### PR TITLE
Update CDC Tableflow skill: Oracle XStream, DynamoDB fixes, doc links

### DIFF
--- a/skills/confluent-cloud-cdc-tableflow/SKILL.md
+++ b/skills/confluent-cloud-cdc-tableflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: confluent-cloud-cdc-tableflow
-description: Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill when users want to capture database changes and materialize them into Iceberg or Delta Lake tables via Confluent Cloud Tableflow. Trigger phrases include "CDC to Tableflow", "database to Iceberg", "database to Delta Lake", "stream database changes to data lake", or "set up Tableflow pipeline". Do NOT trigger for general CDC, Debezium, or database replication requests that do not involve Tableflow or Iceberg/Delta Lake as the destination.
+description: Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. Supports JSON_SR, Avro, and Protobuf formats. Handles schemaless topics (plain JSON without SR) and multi-event topics. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill when users want to capture database changes and materialize them into Iceberg or Delta Lake tables via Confluent Cloud Tableflow. Trigger phrases include "CDC to Tableflow", "database to Iceberg", "database to Delta Lake", "stream database changes to data lake", "set up Tableflow pipeline", "schemaless topic to Tableflow", or "multi-event topic to Iceberg". Do NOT trigger for general CDC, Debezium, or database replication requests that do not involve Tableflow or Iceberg/Delta Lake as the destination.
 ---
 
 # Confluent Cloud CDC to Tableflow Pipeline
@@ -26,9 +26,44 @@ This skill automates the setup of a complete CDC pipeline:
 3. **Confluent Cloud Flink**: Decodes Debezium envelopes and transforms data
 4. **Tableflow**: Native Confluent Cloud feature that materializes Kafka topics as Iceberg or Delta tables
 
+### Critical Architecture Rules
+
+**1. NEVER enable Tableflow directly on CDC source topics.**
+
+Always use the Flink decode pattern: CDC Source Topic → Flink INSERT → Target Topic (`changelog.mode = 'upsert'`) → Tableflow.
+
+CDC connectors with `tombstones.on.delete=true` produce null-value Kafka records (tombstones) on DELETE operations. If Tableflow is enabled directly on the CDC source topic, it will use APPEND mode by default and immediately suspend when it encounters a tombstone: *"Tableflow will be suspended because we detected a Kafka record with a null value."*
+
+The Flink decode layer solves this by interpreting Debezium CDC semantics natively — it translates DELETEs into proper retract/tombstone messages that upsert-mode Tableflow handles correctly.
+
+**Do NOT use `after.state.only=true`** as a shortcut to bypass the Flink decode step. While it strips the Debezium envelope, tombstone records from DELETEs still break APPEND-mode Tableflow. Additionally, `OracleXStreamSource` does not support the `after.state.only` configuration option at all.
+
+**2. Tableflow changelog mode is IMMUTABLE after first materialization.**
+
+Tableflow caches the changelog mode (APPEND or UPSERT) when it first materializes data. Once set, it cannot be changed — even by altering the Kafka topic's `changelog.mode` property or by deleting and recreating the Tableflow topic. The S3 `table_path` is keyed by Kafka topic name, so recreating a Tableflow topic reuses the same S3 path and cached state.
+
+Attempting to change the mode causes: *"The changelog mode for this topic has been modified since table materialization began."* Flip-flopping the mode further corrupts state with: *"Incompatible schema evolution detected."*
+
+**To change changelog mode**, you must delete the Tableflow topic, delete the underlying Kafka topic, and recreate both from scratch. This is why it's critical to create target topics with `'changelog.mode' = 'upsert'` from the start.
+
+**3. Pipeline cleanup order matters.**
+
+When resetting a CDC-to-Tableflow pipeline, delete resources in this order:
+1. Tableflow topics (on target topics)
+2. Flink INSERT statements
+3. Flink target tables (DROP TABLE)
+4. Target Kafka topics
+5. CDC connectors
+6. CDC source Kafka topics (including dbhistory/schema-changes topics)
+7. All associated schemas from Schema Registry (both `-key` and `-value` subjects)
+
+**Never delete CDC source Kafka topics while the connector is still running** — the connector cannot recover or re-snapshot and must be fully recreated.
+
 ### Important Clarifications
 - **Tableflow is NOT a connector.** It is a native topic-level feature enabled via the Tableflow API or Confluent Cloud UI.
 - **Confluent Cloud Flink auto-discovers CDC tables.** You do NOT need to manually create source tables — topics with Schema Registry schemas are automatically available as Flink tables.
+- **Topics without SR schemas** can still be handled — register a JSON schema (partial is fine), use schema inference, or use Flink's raw BYTES with JSON functions. See `references/connector-configs.md` "Handling Topics Without Schema Registry".
+- **All SR-backed formats work identically** — `JSON_SR`, `AVRO`, and `PROTOBUF` all support Flink auto-discovery and Tableflow. Choose based on throughput needs vs. debuggability.
 - **Managed connectors use `output.data.format`**, not `key.converter`/`value.converter` classes.
 
 ## Workflow Phases
@@ -39,14 +74,7 @@ This skill automates the setup of a complete CDC pipeline:
 
 #### 0.1 Verify MCP Server Availability
 
-Check if the Confluent MCP tools are available. Look for tools prefixed with `mcp__confluent__`. Key tools needed:
-- `mcp__confluent__list-environments`
-- `mcp__confluent__list-clusters`
-- `mcp__confluent__create-connector` / `mcp__confluent__read-connector` / `mcp__confluent__delete-connector`
-- `mcp__confluent__create-flink-statement` / `mcp__confluent__read-flink-statement` / `mcp__confluent__list-flink-statements`
-- `mcp__confluent__create-tableflow-topic` / `mcp__confluent__list-tableflow-topics`
-- `mcp__confluent__list-schemas` / `mcp__confluent__list-topics` / `mcp__confluent__consume-messages`
-- `mcp__confluent__search-topics-by-name`
+Check for `mcp__confluent__*` tools (list-environments, create-connector, create-flink-statement, create-tableflow-topic, list-schemas, list-topics, consume-messages, search-topics-by-name).
 
 **If MCP is not available**, fall back to the Confluent CLI (`confluent` command) and REST APIs for all operations. The CLI fallback should mirror the same workflow phases but use CLI commands instead of MCP tool calls.
 
@@ -62,13 +90,23 @@ confluent connect cluster describe <connector-id>
 confluent connect cluster list --cluster <cluster-id> --environment <env-id>
 
 # Flink operations
+confluent flink compute-pool create <pool-name> --cloud <cloud> --region <region> --environment <env-id>
 confluent flink statement create <statement-name> --sql "<SQL>" --compute-pool <pool-id> --environment <env-id>
 confluent flink statement describe <statement-name> --environment <env-id>
+confluent flink statement delete <statement-name> --environment <env-id>
 
 # Topic & schema operations
 confluent kafka topic list --cluster <cluster-id> --environment <env-id>
 confluent schema-registry subject list --environment <env-id>
+
+# Tableflow operations
+confluent tableflow topic enable <topic-name> --cluster <cluster-id> --environment <env-id> --storage-type MANAGED --table-formats ICEBERG
+confluent tableflow topic list --cluster <cluster-id> --environment <env-id>
+confluent tableflow topic describe <topic-name> --cluster <cluster-id> --environment <env-id>
+confluent tableflow topic disable <topic-name> --cluster <cluster-id> --environment <env-id>
 ```
+
+**REST API Fallback:** If neither MCP nor CLI is available, use the Confluent Cloud REST APIs directly. All calls use HTTP Basic Auth with a **Cloud API Key** (not a Kafka API key). See `references/rest-api.md` for endpoint patterns and examples.
 
 #### 0.2 Gather Confluent Cloud Details from the User
 
@@ -82,14 +120,7 @@ Ask the user to provide the following Confluent Cloud details:
 | Flink Catalog Name | `my_environment` | `catalogName` in Flink statements |
 | Flink Database Name | `cluster_0` | `databaseName` in Flink statements |
 
-**Credentials:** Do NOT ask the user to paste credentials in the terminal. Instead, generate a credentials file (e.g., `cdc-credentials.properties`) with placeholder values for the required credentials below, and ask the user to populate it in their editor. When needed for connector creation, read the file to populate the connector config. Ensure the file is added to `.gitignore`. If the user prefers that Claude not read the credentials file, fall back to the Confluent CLI: generate a `connector-config.json` with the credentials as placeholders, let the user fill it in, then run `confluent connect cluster create --config-file connector-config.json` so the CLI reads the file directly. The following credentials are needed:
-
-| Credential | Purpose | Notes |
-|---|---|---|
-| Kafka API Key | Connector authentication to Kafka cluster | `kafka.auth.mode` supports both `SERVICE_ACCOUNT` and `KAFKA_API_KEY` ([docs](https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-debezium/cc-postgresql-cdc-source-v2-debezium.html#kafka-cluster-credentials)) |
-| Kafka API Secret | Connector authentication to Kafka cluster | Paired with the API key above |
-| Database Username | Connector authentication to source database | For database authentication via password |
-| Database Password | Connector authentication to source database | Also supports Google Service Account impersonation for GCP-hosted databases |
+**Credentials:** Generate a `cdc-credentials.properties` file with placeholders for: Kafka API Key/Secret (cluster-scoped), Database Username/Password. Have the user populate it in their editor and add it to `.gitignore`. If the user prefers Claude not read the file, fall back to CLI: generate `connector-config.json` with placeholders, user fills it in, then `confluent connect cluster create --config-file connector-config.json`.
 
 #### 0.3 Verify MCP Cluster Targeting
 
@@ -116,7 +147,30 @@ Ask the user:
 - "Do you have a Flink compute pool you'd like to use, or should I create one?"
 - "Is your database already configured for CDC?"
 
-#### 1.2 Gather Required Information
+#### 1.2 Validate Topic Prefix Uniqueness
+
+Before proceeding, validate that the chosen `topic.prefix` won't collide with existing topics:
+
+```
+mcp__confluent__search-topics-by-name(topicName: "<proposed-prefix>", environmentId, clusterId)
+```
+
+Or via CLI:
+```bash
+confluent kafka topic list --cluster <cluster-id> --environment <env-id> | grep "^<proposed-prefix>"
+```
+
+If any existing topics share the proposed prefix, warn the user and recommend a unique prefix. A prefix collision silently merges CDC data with unrelated topics, which can corrupt both pipelines.
+
+#### 1.3 Check Schema Registry Compatibility
+
+Default `BACKWARD` compatibility can halt CDC connectors when database columns are dropped. Set `FULL_TRANSITIVE` for CDC subjects after the connector creates them:
+
+```bash
+confluent schema-registry config update --subject "<topic-prefix>.<schema>.<table>-value" --compatibility FULL_TRANSITIVE --environment <env-id>
+```
+
+#### 1.4 Gather Required Information
 
 **Database Configuration:**
 - Database type (SQL Server, MySQL, PostgreSQL, Oracle, or DynamoDB)
@@ -124,10 +178,9 @@ Ask the user:
 - Credentials (populated by the user in the credentials file)
 - Specific tables to capture (format: `schema.table`)
 
-**Kafka & Database Credentials:**
-- The CDC connector needs Kafka API keys scoped to the target cluster and database credentials
-- Credentials should be populated by the user in the generated credentials file — read the file when needed for connector creation, or fall back to CLI if the user prefers Claude not read credentials
-- See Phase 0.2 for the full list of required credentials and supported authentication modes
+**Schema Format:** Ask the user: `JSON_SR` (default, human-readable), `AVRO` (smaller payloads, high-throughput), or `PROTOBUF` (strongly typed). All work identically with Flink auto-discovery and Tableflow. **Never use plain `JSON`** — it breaks both. See `references/connector-configs.md` for detailed comparison.
+
+**Existing Topics Without SR:** See `references/connector-configs.md` "Handling Topics Without Schema Registry" for options (register JSON schema, schema inference, or Flink raw BYTES).
 
 **Tableflow Destination:**
 - Target format: Iceberg or Delta Lake
@@ -137,16 +190,23 @@ Ask the user:
 - Default: `cdc-pipeline-skill-{database-type}-{YYYYMMDD}`
 - Example: `cdc-pipeline-skill-postgres-20260323`
 
-#### 1.3 Validate Database Prerequisites
+#### 1.5 Validate Database Prerequisites
 
 Each database requires specific CDC setup. Read `references/database-prerequisites.md` for details:
 - PostgreSQL: WAL level = logical, replication slots, publication
 - MySQL: binlog format = ROW, GTID mode
 - SQL Server: CDC enabled on database and tables, SQL Server Agent running
-- Oracle: Archive log mode, supplemental logging, XStream
+- **Oracle XStream: GoldenGate replication enabled (`enable_goldengate_replication=TRUE`), ARCHIVELOG mode, supplemental logging, XStream admin user with `DBMS_XSTREAM_AUTH` privileges, XStream outbound server created via `DBMS_XSTREAM_ADM.CREATE_OUTBOUND`, connector user with XStream connect privilege. Full prereqs: https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-cdc-source/prereqs-validation.html**
 - DynamoDB: Streams enabled with NEW_AND_OLD_IMAGES
 
 If the database isn't properly configured, guide the user through setup before proceeding.
+
+**Oracle XStream important limitations:**
+- Only supports non-CDB architecture on Amazon RDS for Oracle
+- Does NOT support Oracle Autonomous Databases or Oracle Standby (Data Guard)
+- Does NOT support Downstream Capture
+- `after.state.only` is NOT supported by `OracleXStreamSource`
+- Requires a valid Confluent license for XStream Out
 
 ### Phase 2: Planning
 
@@ -155,6 +215,15 @@ Generate the complete configuration plan and present it to the user for approval
 #### 2.1 Connector Configuration
 
 Based on the database type, generate the connector configuration using the appropriate template from `references/connector-configs.md`. The templates include all required fields (`name`, `connector.class`, `topic.prefix`, `kafka.api.key`, `output.data.format`, `decimal.handling.mode`, etc.) and database-specific settings.
+
+**Set the schema format** based on user preference (default `JSON_SR`):
+```json
+{
+  "output.data.format": "JSON_SR",
+  "output.key.format": "JSON_SR"
+}
+```
+Replace `JSON_SR` with `AVRO` or `PROTOBUF` if the user requested a different format. Both key and value formats should match. All other connector settings remain the same regardless of format choice.
 
 **Topic Naming Pattern:**
 `{topic.prefix}.{schema}.{table}`
@@ -196,18 +265,21 @@ FROM `postgres-cdc.public.customers`;
 - Do NOT reference `after.*` fields or filter by `op` — Flink interprets CDC changelog semantics natively
 - Use `TIMESTAMP_LTZ(3)` for Debezium timestamps, not `TIMESTAMP(3)`
 
-**Debezium Type Conversions:**
-| Debezium Type | Flink Source Type | Target Type | Conversion |
-|---|---|---|---|
-| `MicroTimestamp` | BIGINT (microseconds) | TIMESTAMP_LTZ(3) | `TO_TIMESTAMP_LTZ(col / 1000, 3)` |
-| `Timestamp` | BIGINT (milliseconds) | TIMESTAMP_LTZ(3) | `TO_TIMESTAMP_LTZ(col, 3)` |
-| `Date` | INT (days since epoch) | DATE | Direct or cast |
-| `DECIMAL`/`NUMERIC` | STRING (with `decimal.handling.mode=string`) | DECIMAL or STRING | Direct; without `string` mode, arrives as BYTES which Flink cannot cast |
-| `INTERVAL` (PG/Oracle) | STRING (with `interval.handling.mode=string`) | STRING | Direct; default `numeric` mode is lossy |
-| Binary (BYTEA, BLOB, etc.) | STRING (with `binary.handling.mode=base64`) | STRING | Base64-encoded; default `bytes` breaks JSON |
-| Numeric/String | Direct mapping | Same | No conversion needed |
+**DynamoDB CDC is different from SQL CDC in Flink.** The auto-discovered table has columns `id` (key) and `val` (a complex ROW type containing the CDC envelope with `op`, `before.document`, `after.document`). Flink does NOT auto-decode this envelope like it does for SQL Debezium connectors. You must manually extract fields:
+```sql
+CREATE TABLE `target_dynamodb` (
+  `id` STRING NOT NULL,
+  `document` STRING,
+  PRIMARY KEY (`id`) NOT ENFORCED
+) WITH ('changelog.mode' = 'upsert');
 
-For detailed patterns, see `references/flink-sql-patterns.md`.
+INSERT INTO `target_dynamodb`
+SELECT `id`, `val`.`after`.`document`
+FROM `dynamodb-cdc-source-topic`;
+```
+The `document` field is a JSON string of the DynamoDB item in DynamoDB's native type format (e.g., `{"name":{"S":"Alice"},"age":{"N":"30"}}`).
+
+**Debezium Type Conversions:** See `references/flink-sql-patterns.md` for the full type mapping table. Key conversions: use `TO_TIMESTAMP_LTZ(col / 1000, 3)` for MicroTimestamp, `TO_TIMESTAMP_LTZ(col, 3)` for Timestamp, and ensure `decimal.handling.mode=string` is set on the connector (BYTES default is unusable in Flink).
 
 #### 2.3 Tableflow Configuration
 
@@ -248,23 +320,19 @@ mcp__confluent__create-connector(
 )
 ```
 
-**Verify connector provisioning:**
-Managed connectors take **2-5 minutes** to provision. Poll status:
-```
-mcp__confluent__read-connector(connectorName, environmentId, clusterId)
-```
-- `tasks: []` → Still provisioning, wait and retry
-- `tasks: [{...}]` → Provisioned, tasks assigned
+**Verify:** Managed connectors take **2-5 minutes** to provision. Poll `mcp__confluent__read-connector` — `tasks: []` means still provisioning; `tasks: [{...}]` means ready. Then verify schemas with `mcp__confluent__list-schemas(subjectPrefix: "postgres-cdc")`. If no schemas after 5 min with tasks assigned, check database connectivity. Use Confluent Cloud UI for connector error logs (MCP doesn't expose them).
 
-**Verify data is flowing:**
-```
-mcp__confluent__list-schemas(subjectPrefix: "postgres-cdc")
-```
-When schemas appear (e.g., `postgres-cdc.public.customers-key`, `postgres-cdc.public.customers-value`), the connector is producing data.
+#### 3.2 Create Flink Compute Pool (if needed)
 
-If no schemas appear after 5 minutes with tasks assigned, check database connectivity and credentials. The MCP `read-connector` tool does NOT show error logs — use the Confluent Cloud UI for connector error details.
+If the user doesn't have an existing Flink compute pool, create one before executing SQL:
 
-#### 3.2 Execute Flink SQL
+```
+confluent flink compute-pool create <pool-name> --cloud <cloud-provider> --region <region> --environment <env-id>
+```
+
+Use the same cloud provider and region as the Kafka cluster. Wait for the pool status to be `RUNNING` before proceeding.
+
+#### 3.3 Execute Flink SQL
 
 **Step 1: Verify CDC table is auto-discovered:**
 ```
@@ -315,7 +383,7 @@ mcp__confluent__read-flink-statement(statementName: "cdc-decode-customers", envi
 - "Primary key does not match upsert key" — Expected for CDC decode patterns
 - "Highly state-intensive operators without TTL" — Advisory; set TTL if needed for production
 
-#### 3.3 Enable Tableflow
+#### 3.4 Enable Tableflow
 
 **Using MCP:**
 ```
@@ -329,20 +397,61 @@ mcp__confluent__create-tableflow-topic(
 )
 ```
 
-**KNOWN LIMITATION:** The MCP `create-tableflow-topic` tool does NOT accept `environmentId` or `clusterId` parameters. It defaults to the cluster configured in the MCP server. If the MCP server points to a different cluster than where the target topic exists, this will fail with "topic not found".
+**KNOWN LIMITATION:** The MCP `create-tableflow-topic` tool does NOT accept `environmentId` or `clusterId` parameters. It defaults to the cluster configured in the MCP server. If the MCP server points to a different cluster than where the target topic exists, this will fail with "topic not found". Use the CLI or UI as a workaround.
 
-**Workaround if MCP Tableflow creation fails:**
-- **Use the Confluent Cloud UI**: Environment → Cluster → Topics → `target_customers` → Tableflow tab → Enable
+**Using CLI:**
+```bash
+# Managed storage (Confluent manages S3)
+confluent tableflow topic enable target_customers \
+  --cluster <cluster-id> \
+  --environment <env-id> \
+  --storage-type MANAGED \
+  --table-formats ICEBERG
+
+# BYOB / BYOS (user's own S3 bucket)
+confluent tableflow topic enable target_customers \
+  --cluster <cluster-id> \
+  --environment <env-id> \
+  --storage-type BYOS \
+  --provider-integration <provider-integration-id> \
+  --bucket-name <bucket-name> \
+  --table-formats ICEBERG
+
+# Azure Data Lake Storage Gen2
+confluent tableflow topic enable target_customers \
+  --cluster <cluster-id> \
+  --environment <env-id> \
+  --storage-type AzureDataLakeStorageGen2 \
+  --provider-integration <provider-integration-id> \
+  --storage-account-name <account-name> \
+  --container-name <container-name> \
+  --table-formats DELTA
+```
+
+Use `--table-formats DELTA` for Delta Lake instead of Iceberg.
 
 **Verify Tableflow is enabled:**
 ```
 mcp__confluent__list-tableflow-topics(environmentId, clusterId)
+```
+
+Or via CLI:
+```bash
+confluent tableflow topic describe target_customers --cluster <cluster-id> --environment <env-id>
+confluent tableflow topic list --cluster <cluster-id> --environment <env-id>
 ```
 Status will transition from `PENDING` → `ACTIVE`.
 
 ### Phase 4: Verification & Troubleshooting
 
 #### 4.1 Verify End-to-End Pipeline
+
+**Large Table Snapshots:** If the connector was created with `snapshot.mode: initial` on a large table, verification may take hours. To distinguish a running snapshot from a broken pipeline:
+1. Confirm connector has tasks assigned (`read-connector` → `tasks` is non-empty)
+2. Confirm schemas are registered (`list-schemas` → key/value schemas exist) — this means the snapshot has started producing
+3. Monitor the source topic message count in Confluent Cloud UI — a steady stream means progress
+
+If you used `snapshot.mode: schema_only` for initial validation, insert a test row in the source database to trigger a CDC event and verify the full pipeline. See `references/troubleshooting.md` for detailed snapshot troubleshooting.
 
 **Check each component:**
 
@@ -378,45 +487,25 @@ VALUES ('Test User', 'test@example.com', NOW());
 
 For detailed troubleshooting, see `references/troubleshooting.md`.
 
-**Quick reference for common issues:**
+**Quick reference — pipeline-blocking issues:**
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
-| Connector creation fails: "topic.prefix is required" | Missing required field | Add `"topic.prefix"` to connector config |
 | Connector tasks stay empty | Still provisioning | Wait 2-5 minutes, retry |
 | No schemas after 5 min | DB connectivity or credentials | Check host, port, user, password; verify DB CDC config |
-| MySQL: "LOCK TABLES privilege required" | Managed MySQL lacks SUPER privilege | `GRANT LOCK TABLES ON db.* TO 'user'@'%';` — required for RDS, Aurora, Cloud SQL, Azure MySQL |
 | SHOW TABLES missing CDC table | Connector not producing yet | Verify schemas exist first, then wait |
-| CREATE TABLE: "Unsupported format" | Explicit format specs | Remove all `'value.format'`, `'connector'` properties |
-| INSERT: "Incompatible types" | Debezium type mismatch | Use TIMESTAMP_LTZ(3) + TO_TIMESTAMP_LTZ conversion |
-| Tableflow: "topic not found" | MCP cluster mismatch | Use Confluent Cloud UI to enable Tableflow |
-| DECIMAL columns show garbled bytes | Missing `decimal.handling.mode` | Add `"decimal.handling.mode": "string"` to connector config; must fix at connector level, not Flink |
-| INTERVAL columns show large integers | Missing `interval.handling.mode` | Add `"interval.handling.mode": "string"` for PG/Oracle; default is lossy microseconds |
-| Binary columns break JSON | Missing `binary.handling.mode` | Add `"binary.handling.mode": "base64"` for BYTEA/VARBINARY/BLOB/RAW columns |
-| Oracle NUMBER produces struct not scalar | Oracle NUMBER without precision | Add `"decimal.handling.mode": "string"` — default produces VariableScaleDecimal struct |
-| Flink DEGRADED: "Schema ID not found" | Stale schema IDs on topics after schema deletion | Delete CDC source topics + hard-delete schemas + drop replication slot, then recreate connector fresh |
-| consume-messages returns 0 | Consumer at latest offset | Insert a new row in DB, or MCP targets wrong cluster |
+| INSERT: "Incompatible types" | Debezium type mismatch | Use TIMESTAMP_LTZ(3) + TO_TIMESTAMP_LTZ; see `references/flink-sql-patterns.md` |
+| Tableflow: "topic not found" | MCP cluster mismatch | Use CLI: `confluent tableflow topic enable` or Confluent Cloud UI |
+| Topic exists but not in SHOW TABLES | No schema in SR | Register a JSON schema in SR or use schema inference; see `references/connector-configs.md` |
 
 ### Phase 5: Documentation
 
 After successful setup, provide the user with:
 
 1. **Pipeline Summary Table**: All component names, IDs, and statuses
-2. **Topic Names**: Source CDC topic and target JSON_SR topic
+2. **Topic Names**: Source CDC topic and target topic (with schema format used)
 3. **Monitoring**: Check connector, Flink job, and Tableflow status in Confluent Cloud UI
 4. **Test Command**: SQL INSERT to verify real-time CDC
-
-## Important Notes
-
-- **Tableflow is NOT a connector** — It's a native topic feature enabled via API or UI
-- **Cloud Flink auto-discovers CDC tables** — No manual source table creation needed
-- **Managed connectors use `output.data.format`** — Not converter classes
-- **`topic.prefix` is REQUIRED** — Controls topic naming for all CDC V2 connectors
-- **Schema Evolution**: Database schema changes require updating Flink target table and INSERT job
-- **Scaling**: Increase Flink compute pool CFU for higher throughput
-- **Cost**: CDC connectors, Flink CFUs, and Tableflow all incur costs
-- **Tableflow works with any cluster type** — Basic, Standard, Dedicated, and Enterprise clusters all support Tableflow
-- **Generate a credentials file** — Create a sample credentials file with placeholders for Kafka API keys and database credentials. Ask the user to fill it in. Do NOT ask the user to paste credentials in the terminal. Read the file when needed for connector creation via MCP. If the user prefers Claude not read credentials, fall back to the Confluent CLI (`confluent connect cluster create --config-file connector-config.json`). Supports `SERVICE_ACCOUNT` and `KAFKA_API_KEY` auth modes for Kafka, and password or Google Service Account impersonation for databases.
 
 ## References
 
@@ -424,6 +513,7 @@ After successful setup, provide the user with:
 - Connector Configurations: `references/connector-configs.md`
 - Flink SQL Patterns: `references/flink-sql-patterns.md`
 - Troubleshooting Guide: `references/troubleshooting.md`
+- REST API Reference: `references/rest-api.md`
 - Confluent Cloud Flink Docs: https://docs.confluent.io/cloud/current/flink/overview.html
 - Tableflow Docs: https://docs.confluent.io/cloud/current/topics/tableflow/overview.html
 - Debezium CDC Docs: https://debezium.io/documentation/

--- a/skills/confluent-cloud-cdc-tableflow/evals/evals.json
+++ b/skills/confluent-cloud-cdc-tableflow/evals/evals.json
@@ -9,7 +9,7 @@
       "assertions": [
         {"name": "Creates PostgreSQL CDC connector configuration", "description": "Should generate a PostgreSQL CDC V2 connector config file (JSON)"},
         {"name": "Includes both tables in connector config", "description": "Connector config should have table.include.list with 'public.users' and 'public.orders'"},
-        {"name": "Uses JSON_SR format", "description": "Connector config should specify output.data.format = JSON_SR"},
+        {"name": "Uses SR-backed format", "description": "Connector config should specify output.data.format as JSON_SR, AVRO, or PROTOBUF (not plain JSON)"},
         {"name": "Creates Flink compute pool", "description": "Should include commands or plan to create a Flink compute pool"},
         {"name": "Generates Flink SQL for both tables", "description": "Should create source and target table DDL plus INSERT statements for users and orders"},
         {"name": "Creates Tableflow sink configuration", "description": "Should generate Tableflow connector config for Iceberg with S3 path"},
@@ -49,7 +49,7 @@
       "assertions": [
         {"name": "Creates SQL Server CDC V2 connector configuration", "description": "Should generate a SQL Server CDC V2 connector config file (JSON)"},
         {"name": "Includes all three tables", "description": "Connector config should have table.include.list with 'dbo.Customers', 'dbo.Invoices', 'dbo.LineItems'"},
-        {"name": "Uses JSON_SR format", "description": "Connector config should specify output.data.format = JSON_SR (not AVRO)"},
+        {"name": "Uses JSON_SR format per user request", "description": "Connector config should specify output.data.format = JSON_SR since user requested JSON with Schema Registry"},
         {"name": "Configures Tableflow for ADLS Gen2", "description": "Tableflow sink should use Azure Data Lake Storage Gen2 path (abfss:// format)"},
         {"name": "Uses sales-cdc naming prefix", "description": "All component names should start with 'sales-cdc-' as requested"}
       ]
@@ -89,6 +89,42 @@
         {"name": "Provides steps to update Flink target table", "description": "Should explain how to drop and recreate the target table DDL with new column"},
         {"name": "Explains how to restart INSERT statement", "description": "Should provide commands to stop existing INSERT statement and start new one"},
         {"name": "References schema evolution pattern", "description": "Should mention or reference Pattern 5 from flink-sql-patterns.md"}
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "We want to set up CDC from our PostgreSQL database to Iceberg, but we need to use Avro format instead of JSON because we have very high throughput — about 50k events per second. Database is at pg-analytics.internal:5432, database name is 'events', table is 'public.page_views'. We have a Flink pool lfcp-htp001 and everything else is set up. Can you generate configs with Avro?",
+      "expected_output": "Setup plan using AVRO format: (1) PostgreSQL CDC connector with output.data.format = AVRO and output.key.format = AVRO, (2) Flink SQL using auto-discovered CDC table (same patterns as JSON_SR — Flink handles all formats transparently), (3) Tableflow for Iceberg. Should explain that Avro is a good choice for high throughput due to smaller payloads.",
+      "files": [],
+      "assertions": [
+        {"name": "Uses AVRO format", "description": "Connector config should specify output.data.format = AVRO and output.key.format = AVRO"},
+        {"name": "Flink patterns are format-agnostic", "description": "Flink SQL should use the same auto-discovery and INSERT patterns as JSON_SR — no format-specific changes"},
+        {"name": "Explains Avro benefits for throughput", "description": "Should mention that Avro produces smaller payloads than JSON_SR, beneficial for high throughput"}
+      ]
+    },
+    {
+      "id": 9,
+      "prompt": "I have an existing Kafka topic called 'app-events' that receives plain JSON messages (no Schema Registry) from our application. The messages look like {\"user_id\": 123, \"action\": \"click\", \"timestamp\": 1710000000000, \"page\": \"/home\"}. I want to get this data into an Iceberg table via Tableflow. How do I handle the fact that there's no schema registered?",
+      "expected_output": "Should explain multiple options for handling schemaless topics: (1) Register a JSON schema manually in SR (partial schema is fine for JSON), (2) Use Confluent Cloud's schema inference feature, (3) Use Flink raw BYTES inference with ALTER TABLE MODIFY and JSON functions. Should recommend Option 1 or 2 as preferred. Should explain that Tableflow requires schemas.",
+      "files": [],
+      "assertions": [
+        {"name": "Identifies schemaless topic issue", "description": "Should recognize that plain JSON without SR means no Flink auto-discovery and no Tableflow"},
+        {"name": "Recommends schema registration", "description": "Should recommend registering a JSON schema in SR as the preferred approach"},
+        {"name": "Mentions partial schema support", "description": "Should note that JSON schemas can be partial — not all fields need to be defined"},
+        {"name": "Mentions schema inference", "description": "Should reference Confluent Cloud's ability to infer schemas from existing messages"},
+        {"name": "Shows BYTES fallback", "description": "Should explain the ALTER TABLE MODIFY approach with JSON_VALUE functions as an alternative"}
+      ]
+    },
+    {
+      "id": 10,
+      "prompt": "We have a Kafka topic called 'all-changes' that receives CDC events from multiple tables — orders, customers, and products are all routed to the same topic using Debezium's topic routing SMT. Each message has an 'event_type' field indicating which table it came from. We need to split these into separate Iceberg tables via Tableflow. How should we handle this?",
+      "expected_output": "Should explain that multi-event topics require splitting before Tableflow. Recommend creating separate Flink INSERT jobs that filter by event_type and write to separate target tables. Each target table gets its own schema and can be used with Tableflow normally. Should also recommend avoiding multi-event topics for future CDC pipelines.",
+      "files": [],
+      "assertions": [
+        {"name": "Identifies multi-event topic challenge", "description": "Should recognize that Tableflow works best with single-schema topics"},
+        {"name": "Recommends splitting via Flink", "description": "Should suggest using Flink SQL to filter by event_type and route to separate target tables"},
+        {"name": "Creates separate Tableflow targets", "description": "Should enable Tableflow on each separate target table, not the multi-event source"},
+        {"name": "Recommends avoiding multi-event for CDC", "description": "Should advise using Debezium's default one-topic-per-table for future pipelines"}
       ]
     }
   ]

--- a/skills/confluent-cloud-cdc-tableflow/references/connector-configs.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/connector-configs.md
@@ -38,9 +38,38 @@ All connectors share these common settings:
 **REQUIRED field: `topic.prefix`** — Controls topic naming. All CDC V2 connectors require this. Topics will be named `{topic.prefix}.{schema}.{table}`.
 
 **Schema Format Options:**
-- `JSON_SR` (default, recommended — JSON with Schema Registry, uses schema ID in header which is safer for downstream consumers and won't break existing consumers)
-- `AVRO` (binary format, requires Avro-compatible consumers)
-- `PROTOBUF`
+- `JSON_SR` (default, recommended — JSON with Schema Registry, uses schema ID in header; human-readable payloads, easiest to debug with `consume-messages`)
+- `AVRO` (binary format — more compact and efficient for high-throughput pipelines; requires Avro-compatible consumers; best for large-scale production CDC)
+- `PROTOBUF` (binary format — strongly typed with nested message support; good when downstream consumers already use Protobuf)
+
+**Format selection guidance:**
+| Criteria | JSON_SR | AVRO | PROTOBUF |
+|---|---|---|---|
+| Debugging / readability | Best — human-readable payloads | Poor — binary | Poor — binary |
+| Throughput / message size | Largest payloads | ~30-50% smaller than JSON_SR | ~30-50% smaller than JSON_SR |
+| Flink auto-discovery | Yes | Yes | Yes |
+| Tableflow compatibility | Yes | Yes | Yes |
+| Schema evolution | Supported via SR | Best support via SR | Supported via SR |
+
+All three formats register schemas in Schema Registry and work identically with Flink auto-discovery and Tableflow. The choice is primarily about payload size vs. debuggability.
+
+**Important:** `output.data.format` and `output.key.format` must both use a Schema Registry-backed format (`JSON_SR`, `AVRO`, or `PROTOBUF`). Using plain `JSON` (without SR) means no schema is registered, which breaks Flink auto-discovery and Tableflow. See "Handling Topics Without Schema Registry" below.
+
+To use Avro or Protobuf, change both format fields in the connector config:
+```json
+{
+  "output.data.format": "AVRO",
+  "output.key.format": "AVRO"
+}
+```
+or:
+```json
+{
+  "output.data.format": "PROTOBUF",
+  "output.key.format": "PROTOBUF"
+}
+```
+All other connector settings (type mappings, snapshot mode, etc.) remain the same regardless of format.
 
 **Note on managed connectors:** Fields like `kafka.auth.mode` and `kafka.endpoint` are auto-configured by Confluent Cloud when using MCP or the CLI. You only need to provide `kafka.api.key` and `kafka.api.secret`.
 
@@ -93,21 +122,14 @@ All connectors share these common settings:
 }
 ```
 
-**Key Parameters:**
-- `topic.prefix`: **REQUIRED** — Controls topic naming (e.g., `postgres-cdc`)
-- `decimal.handling.mode`: **Always set to `string`.** Without it, Debezium serializes DECIMAL/NUMERIC/MONEY columns as raw bytes (Java BigDecimal unscaled value), producing garbled data like `"N\u001f"` instead of `"199.99"`. Flink cannot CAST BYTES to DECIMAL, so this must be fixed at the connector level.
-- `interval.handling.mode`: Set to `string` for PostgreSQL INTERVAL columns. Default `numeric` approximates intervals as microseconds (months = 30 days, years = 365.25 days), which is lossy. `string` outputs ISO 8601 format like `P1Y2M3DT4H5M6.78S`.
-- `hstore.handling.mode`: Set to `map` if using PostgreSQL HSTORE columns. Default `json` serializes as a JSON string inside a STRING field; `map` produces a native Kafka Connect MAP type.
-- `binary.handling.mode`: Set to `base64` if using BYTEA columns. Default `bytes` can break JSON serialization.
-- `database.server.name`: Logical name for this database server
-- `table.include.list`: Comma-separated list of tables (format: `schema.table`)
+**PostgreSQL-specific parameters:**
 - `plugin.name`: Use `pgoutput` (native PostgreSQL logical replication)
 - `publication.name`: Publication created in PostgreSQL
 - `slot.name`: Replication slot name (must be unique)
-- `snapshot.mode`:
-  - `initial`: Snapshot existing data, then stream changes
-  - `never`: Only stream changes (no initial snapshot)
-  - `always`: Always snapshot on startup
+- `interval.handling.mode`: Set to `string` for INTERVAL columns (default `numeric` is lossy)
+- `hstore.handling.mode`: Set to `map` for HSTORE columns
+
+For `topic.prefix`, `decimal.handling.mode`, `binary.handling.mode`, `snapshot.mode`, and other shared settings, see Common Configuration Elements and Configuration Best Practices above.
 
 **Topic Naming:**
 Topic pattern: `<topic.prefix>.<schema>.<table>`
@@ -160,16 +182,11 @@ https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-d
 }
 ```
 
-**Key Parameters:**
+**MySQL-specific parameters:**
 - `database.server.id`: Unique numeric ID for this connector (5-10 digits)
-- `topic.prefix`: **REQUIRED** — Controls topic naming
-- `decimal.handling.mode`: **Always set to `string`.** Same raw bytes issue as PostgreSQL for DECIMAL/NUMERIC columns.
-- `binary.handling.mode`: Set to `base64` if using BINARY/VARBINARY/BLOB columns. Default `bytes` breaks JSON serialization.
-- `database.server.name`: Logical name for this database server
 - `database.include.list`: Comma-separated list of databases
-- `table.include.list`: Comma-separated list of tables (format: `database.table`)
+- `table.include.list`: Format: `database.table` (not `schema.table`)
 - `gtid.source.includes`: GTID filter (use `.*` for all)
-- `snapshot.mode`: Same options as PostgreSQL
 
 **Topic Naming:**
 Topic pattern: `<topic.prefix>.<database>.<table>`
@@ -219,14 +236,9 @@ https://docs.confluent.io/cloud/current/connectors/cc-mysql-cdc-source-v2-debezi
 }
 ```
 
-**Key Parameters:**
-- `topic.prefix`: **REQUIRED** — Controls topic naming
-- `decimal.handling.mode`: **Always set to `string`.** Affects DECIMAL, NUMERIC, MONEY, and SMALLMONEY columns — same raw bytes issue as PostgreSQL.
-- `binary.handling.mode`: Set to `base64` if using BINARY/VARBINARY/IMAGE columns.
+**SQL Server-specific parameters:**
 - `database.names`: Comma-separated list of databases
-- `database.server.name`: Logical name for this database server
-- `table.include.list`: Comma-separated list of tables (format: `schema.table`, use `dbo` for default schema)
-- `snapshot.mode`: Same options as PostgreSQL
+- `table.include.list`: Format: `schema.table` (use `dbo` for default schema)
 
 **Topic Naming:**
 Topic pattern: `<topic.prefix>.<schema>.<table>`
@@ -255,11 +267,13 @@ https://docs.confluent.io/cloud/current/connectors/cc-microsoft-sql-server-cdc-s
   "database.user": "<oracle-user>",
   "database.password": "<oracle-password>",
   "database.dbname": "<service-name-or-sid>",
+  "database.service.name": "<service-name-or-sid>",
   "database.server.name": "<logical-server-name>",
   "topic.prefix": "<topic-prefix>",
 
   "database.connection.adapter": "xstream",
   "database.out.server.name": "dbz_outbound",
+  "database.processor.licenses": "1",
 
   "table.include.list": "<schema>.<table1>,<schema>.<table2>",
 
@@ -278,24 +292,28 @@ https://docs.confluent.io/cloud/current/connectors/cc-microsoft-sql-server-cdc-s
 }
 ```
 
-**Key Parameters:**
-- `decimal.handling.mode`: **Always set to `string`.** Affects `NUMBER(p,s)` columns. Oracle `NUMBER` and `FLOAT` without explicit precision are especially problematic — Debezium serializes them as `VariableScaleDecimal`, a struct containing a bytes field, which breaks differently than regular decimals.
-- `interval.handling.mode`: Set to `string` for `INTERVAL YEAR TO MONTH` and `INTERVAL DAY TO SECOND` columns. Default `numeric` approximates as microseconds, which is lossy for month/year intervals.
-- `binary.handling.mode`: Set to `base64` if using RAW or BLOB columns.
+**Oracle-specific parameters:**
 - `database.dbname`: Oracle service name or SID
+- `database.service.name`: **Required.** Oracle service name (often same as `database.dbname`)
+- `database.processor.licenses`: **Required.** Number of Oracle processor licenses (use `"1"` for testing)
 - `database.connection.adapter`: Use `xstream` for XStream
 - `database.out.server.name`: XStream outbound server name (created in Oracle)
-- `topic.prefix`: **REQUIRED** — Controls topic naming
-- `table.include.list`: Comma-separated list of tables (format: `SCHEMA.TABLE` - uppercase)
-- `snapshot.mode`: Same options as PostgreSQL
+- `table.include.list`: Format: `SCHEMA.TABLE` (uppercase)
+- `interval.handling.mode`: Set to `string` for INTERVAL columns (same as PostgreSQL)
+- Oracle `NUMBER`/`FLOAT` without precision produces `VariableScaleDecimal` struct — `decimal.handling.mode: string` fixes this
+- **`after.state.only` is NOT supported** by OracleXStreamSource — do not use this option
 
 **Topic Naming:**
 Topic pattern: `<topic.prefix>.<schema>.<table>`
 
 Example: `oracle-cdc.HR.EMPLOYEES`
 
+**Prerequisites:** Oracle XStream requires significant database-side setup before the connector can be deployed — GoldenGate replication must be enabled, ARCHIVELOG mode configured, supplemental logging set up, an XStream admin user created, and an XStream outbound server provisioned. See `references/database-prerequisites.md` "Oracle XStream CDC Prerequisites" for the complete step-by-step guide.
+
+**Prerequisites validation:** https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-cdc-source/prereqs-validation.html
+
 **Documentation:**
-https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-source/cc-oracle-xstream-source.html
+https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-cdc-source/cc-oracle-xstream-cdc-source.html
 
 ---
 
@@ -313,24 +331,33 @@ https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-source/cc-o
 
   "aws.access.key.id": "<aws-access-key>",
   "aws.secret.access.key": "<aws-secret-key>",
-  "aws.dynamodb.region": "<aws-region>",
 
-  "table.include.list": "<table1>,<table2>",
-
-  "kafka.topic": "cdc-pipeline-skill-dynamodb-<table-name>",
+  "dynamodb.service.endpoint": "https://dynamodb.<aws-region>.amazonaws.com",
+  "dynamodb.table.discovery.mode": "INCLUDELIST",
+  "dynamodb.table.sync.mode": "SNAPSHOT_CDC",
+  "dynamodb.table.includelist": "<table1>,<table2>",
 
   "output.data.format": "JSON_SR",
-  "output.key.format": "JSON_SR",
+
+  "dynamodb.cdc.max.poll.records": "5000",
+  "dynamodb.snapshot.max.poll.records": "1000",
 
   "tasks.max": "1"
 }
 ```
 
 **Key Parameters:**
-- `aws.access.key.id` / `aws.secret.access.key`: IAM credentials with DynamoDB Streams permissions
-- `aws.dynamodb.region`: AWS region where DynamoDB table is located
-- `table.include.list`: Comma-separated list of DynamoDB table names
-- `kafka.topic`: Topic name pattern (use table name variable)
+- `aws.access.key.id` / `aws.secret.access.key`: IAM credentials with DynamoDB Streams **and** checkpointing table write permissions (see `references/database-prerequisites.md` for the complete IAM policy)
+- `dynamodb.service.endpoint`: **Required.** Full DynamoDB service URL including region (e.g., `https://dynamodb.us-east-2.amazonaws.com`)
+- `dynamodb.table.discovery.mode`: **Required.** Set to `INCLUDELIST` for explicit table names, or `TAG` for tag-based auto-discovery
+- `dynamodb.table.sync.mode`: Snapshot behavior — `SNAPSHOT_CDC` (default, snapshot then stream), `SNAPSHOT` (one-time scan only), or `CDC` (streams only, no initial snapshot)
+- `dynamodb.table.includelist`: **Required when discovery mode is INCLUDELIST.** Comma-separated list of DynamoDB table names (note: this is `dynamodb.table.includelist`, NOT `table.include.list` like SQL connectors)
+- `dynamodb.cdc.max.poll.records`: Max records per DynamoDB Streams GetRecords call (each call also limited to 1 MB)
+- `dynamodb.snapshot.max.poll.records`: Max records per DynamoDB Scan call during snapshot (each call also limited to 1 MB)
+
+**tasks.max for DynamoDB:** A single DynamoDB table can only be processed by one task. `tasks.max` should equal the number of tables in `dynamodb.table.includelist`. Configuring more tasks than tables results in idle tasks. For multi-table setups, increase `tasks.max` to match — especially during snapshot to avoid the 24-hour DynamoDB Streams expiry window.
+
+**Critical IAM note:** The CDC phase requires write permissions to create and manage a KCL-style checkpointing table in DynamoDB. Without `CreateTable`, `PutItem`, `GetItem`, `UpdateItem`, `DeleteItem` permissions, the snapshot will succeed but CDC streaming will silently fail (no real-time changes captured). This is the most common cause of DynamoDB CDC appearing "stuck" after snapshot. See `references/database-prerequisites.md` for the complete IAM policy and `references/troubleshooting.md` "DynamoDB CDC: Snapshot Works but CDC Streaming Silently Fails" for diagnosis steps.
 
 **Topic Naming:**
 Topic pattern: `<kafka.topic>` (configurable, unlike other connectors)
@@ -363,11 +390,7 @@ Debezium's default serialization modes can produce raw bytes, lossy approximatio
 | `interval.handling.mode` | `numeric` | Intervals approximated as microseconds (lossy) | `string` | PG: INTERVAL. Oracle: INTERVAL YEAR TO MONTH, INTERVAL DAY TO SECOND |
 | `hstore.handling.mode` | `json` | HSTORE as JSON string, not native MAP | `map` | PG: HSTORE |
 
-**Database-specific quirks with no config toggle:**
-- **MySQL `TINYINT(1)`**: Serialized as INT16, not BOOLEAN. Fix: add `converters=bool` with `TinyIntOneToBooleanConverter` (note: may not be available on all managed connector versions).
-- **MySQL `BIGINT UNSIGNED`**: Default `long` silently overflows for values > 2^63. Setting `bigint.unsigned.handling.mode = precise` avoids overflow but produces bytes (same issue as decimals).
-- **SQL Server `DATETIMEOFFSET`**: Serialized as STRING with timezone offset. Flink may not auto-parse — requires explicit cast.
-- **Oracle `NUMBER` (no precision)**: Serialized as `VariableScaleDecimal` (a struct containing bytes), not plain bytes. `decimal.handling.mode = string` fixes this.
+**Database-specific quirks:** MySQL `TINYINT(1)` → INT16 not BOOLEAN; MySQL `BIGINT UNSIGNED` overflows at 2^63; SQL Server `DATETIMEOFFSET` → STRING; Oracle `NUMBER` (no precision) → `VariableScaleDecimal` struct (fixed by `decimal.handling.mode = string`).
 
 ### Secrets Management
 
@@ -390,50 +413,193 @@ Debezium's default serialization modes can produce raw bytes, lossy approximatio
 
 - `initial`: Snapshot existing data on first run, then stream changes (recommended for new connectors)
 - `never`: Skip snapshot, only capture new changes (use when you don't need historical data)
+- `schema_only`: Snapshot the schema but not the data, then stream changes (use for initial pipeline validation on large tables)
 - `always`: Always snapshot on restart (use for testing, not production)
 
-### Tombstones
+**Large tables (100M+ rows):** Use `schema_only` first to validate the pipeline end-to-end, then recreate with `initial`. The initial snapshot can lock the source DB, burst-produce to Kafka, and trigger SR rate limits — you don't want to wait hours to discover a config error.
 
-Always enable tombstones for proper delete handling:
+### Other Settings (Already in Templates)
+
+The connector templates above include correct defaults for these — only adjust if needed:
+- **`tombstones.on.delete: true`** — Produces null-value record on delete; important for log compaction and downstream consumers
+- **`include.schema.changes: false`** — Suppresses DDL noise in the pipeline
+- **`heartbeat.interval.ms: 30000`** — Detects stalled connectors (PostgreSQL template only)
+- **`tasks.max: 1`** — Ensures message ordering; only increase for high-throughput with careful testing
+
+### Handling Topics Without Schema Registry
+
+If a topic was produced with plain `JSON` (no SR serializer), no schema is registered in Schema Registry. This affects Flink auto-discovery and Tableflow, but there are several ways to handle it.
+
+**Option 1: Register a JSON schema manually in Schema Registry (recommended)**
+
+Register a JSON schema for the topic's subject in Schema Registry. Once registered, Flink will infer the schema and read the topic as if it were serialized with SR serializers — no re-ingestion needed.
+
+For JSON topics, the schema can be **partial** — you don't have to define every field, just the ones you need. Flink will map the defined fields and ignore the rest.
+
+Register via CLI:
+```bash
+confluent schema-registry schema create --subject "<topic-name>-value" --schema schema.json --type JSON --environment <env-id>
+```
+
+Or use the Confluent Cloud UI: Schema Registry → Subjects → Create Subject → paste the JSON Schema.
+
+**Option 2: Infer a schema from existing messages**
+
+Confluent Cloud can [infer a schema from messages](https://docs.confluent.io/cloud/current/sr/schemas-manage.html#infer-a-schema-from-messages) already on the topic. This auto-generates a schema from sample payloads and registers it in SR. After inference, Flink auto-discovers the topic normally.
+
+**Option 3: Use Flink's raw BYTES inference and parse with JSON functions**
+
+For topics with no schema at all, Flink infers a raw table:
+```sql
+-- Flink auto-infers schemaless topics as raw bytes
+CREATE TABLE inferred_raw (`key` BYTES, `val` BYTES);
+
+-- Switch to STRING to work with JSON payloads
+ALTER TABLE inferred_raw MODIFY (`key` STRING, `val` STRING);
+
+-- Then use JSON functions to extract fields
+INSERT INTO target_table
+SELECT
+  JSON_VALUE(val, '$.id' RETURNING INT) AS id,
+  JSON_VALUE(val, '$.name') AS name,
+  JSON_VALUE(val, '$.email') AS email
+FROM inferred_raw;
+```
+
+This is useful when you can't register a schema or need ad-hoc exploration, but it's more fragile than schema-based approaches.
+
+**Option 4: Re-create the connector with an SR-backed format**
+
+If you control the producer, change `output.data.format` from `JSON` to `JSON_SR`, `AVRO`, or `PROTOBUF`. Delete the old connector and topics, then recreate. This is the cleanest path for new CDC pipelines.
+
+**Important format note for schema registration:**
+- **JSON**: Partial schemas are fine — define only the fields you need
+- **Avro**: Must define the complete schema matching the payload structure (binary format, partial schemas won't decode correctly)
+- **Protobuf**: Must define the complete schema matching the payload structure (binary format, same as Avro)
+
+**For new CDC pipelines**, always use `JSON_SR`, `AVRO`, or `PROTOBUF` — never plain `JSON`.
+
+### Subject Name Strategies
+
+The **subject name strategy** controls how Schema Registry subjects are named when schemas are registered. This directly affects whether Flink can auto-discover topics and whether Tableflow can work with them. There are three strategies:
+
+#### TopicNameStrategy (Default)
+
+**Subject pattern:** `<topic-name>-key` / `<topic-name>-value`
+
+```
+Topic: postgres-cdc.public.customers
+  → Key subject:   postgres-cdc.public.customers-key
+  → Value subject: postgres-cdc.public.customers-value
+
+Topic: postgres-cdc.public.orders
+  → Key subject:   postgres-cdc.public.orders-key
+  → Value subject: postgres-cdc.public.orders-value
+```
+
+**Behavior:** One schema per topic. Every record on a given topic must conform to the same schema (with compatible evolution). This is the Debezium default — each captured table gets its own topic and its own schema subject.
+
+| Aspect | Status |
+|---|---|
+| Flink auto-discovery | **Works** — one schema per topic, Flink maps it directly to a table |
+| Tableflow | **Works** — single schema per topic maps cleanly to Iceberg/Delta columns |
+| Schema evolution | Governed by subject-level compatibility (e.g., `BACKWARD`, `FULL_TRANSITIVE`) |
+| Multi-table CDC | Each table on its own topic — no conflicts |
+
+**This is the recommended strategy for CDC-to-Tableflow pipelines.**
+
+#### RecordNameStrategy
+
+**Subject pattern:** `<fully-qualified-record-name>-key` / `<fully-qualified-record-name>-value`
+
+```
+Topic: all-cdc-events  (multiple tables routed here)
+  → Record "com.example.Customer" → Value subject: com.example.Customer-value
+  → Record "com.example.Order"    → Value subject: com.example.Order-value
+```
+
+**Behavior:** The subject is derived from the record's fully qualified name (namespace + name), not the topic. Multiple different schemas can coexist on the same topic because each record type gets its own subject.
+
+| Aspect | Status |
+|---|---|
+| Flink auto-discovery | **Does NOT work** — Flink expects one schema per topic; it cannot resolve multiple SR subjects for the same topic |
+| Tableflow | **Does NOT work reliably** — mixed schemas on one topic produce inconsistent Iceberg/Delta files |
+| Schema evolution | Each record type evolves independently (different subjects) |
+| Use case | Shared topics where multiple event types are intentionally co-located |
+
+**Configuration (self-managed connectors):**
 ```json
 {
-  "tombstones.on.delete": "true"
+  "value.converter.value.subject.name.strategy": "io.confluent.kafka.serializers.subject.RecordNameStrategy"
 }
 ```
 
-This produces a null-value record when a row is deleted, which is important for downstream consumers.
+**Note:** For Confluent Cloud fully-managed connectors, the subject name strategy may not be directly configurable. Check the specific connector documentation.
 
-### Schema Changes
+#### TopicRecordNameStrategy
 
-For production, usually disable schema change events:
+**Subject pattern:** `<topic-name>-<fully-qualified-record-name>-key` / `<topic-name>-<fully-qualified-record-name>-value`
+
+```
+Topic: all-cdc-events
+  → Record "com.example.Customer" → Value subject: all-cdc-events-com.example.Customer-value
+  → Record "com.example.Order"    → Value subject: all-cdc-events-com.example.Order-value
+```
+
+**Behavior:** Combines the topic name and record name. Like `RecordNameStrategy`, it allows multiple schemas per topic, but subjects are scoped to both topic and record type. This means the same record type on different topics gets separate subjects (unlike `RecordNameStrategy` where they'd share one).
+
+| Aspect | Status |
+|---|---|
+| Flink auto-discovery | **Does NOT work** — same limitation as `RecordNameStrategy`; Flink can't resolve compound subjects |
+| Tableflow | **Does NOT work reliably** — same issue as `RecordNameStrategy` |
+| Schema evolution | Each topic+record combination evolves independently |
+| Use case | Multiple topics with overlapping record types that need independent evolution |
+
+**Configuration (self-managed connectors):**
 ```json
 {
-  "include.schema.changes": "false"
+  "value.converter.value.subject.name.strategy": "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy"
 }
 ```
 
-Schema changes (DDL) are captured separately and can create noise in the pipeline.
+#### Strategy Comparison Summary
 
-### Heartbeat
+| | TopicNameStrategy | RecordNameStrategy | TopicRecordNameStrategy |
+|---|---|---|---|
+| Subject derived from | Topic name | Record name | Topic + Record name |
+| Schemas per topic | One | Many | Many |
+| Flink auto-discovery | Yes | No | No |
+| Tableflow | Yes | No | No |
+| Debezium default | Yes | No | No |
+| CDC-to-Tableflow ready | **Yes** | Requires splitting | Requires splitting |
 
-Enable heartbeat to detect stalled connectors:
-```json
-{
-  "heartbeat.interval.ms": "30000",
-  "heartbeat.action.query": "INSERT INTO heartbeat (ts) VALUES (NOW())"
-}
-```
+### Multi-Event Topics
 
-Heartbeat produces a special event every N milliseconds to show the connector is alive.
+A **multi-event topic** contains records with different schemas on the same Kafka topic. By default, Debezium creates one topic per captured table (`{topic.prefix}.{schema}.{table}`) using `TopicNameStrategy`, so each topic has a single event type. Multi-event topics occur when:
 
-### Task Parallelism
+- Topic routing is used (e.g., Debezium's `transforms.route` SMT to merge multiple tables into one topic)
+- An upstream producer writes different event types to the same topic
+- `RecordNameStrategy` or `TopicRecordNameStrategy` is configured (see above)
 
-Most CDC connectors work best with `tasks.max = 1` because:
-- Single-task ensures message ordering per table
-- Database transactions are sequential
-- Parallel tasks can cause out-of-order events
+**Handling multi-event topics for Tableflow:**
 
-Only increase for very high-throughput scenarios with careful testing.
+1. **Best approach — avoid them for CDC:** Use Debezium's default `TopicNameStrategy` with one-topic-per-table. This is the standard and recommended pattern for CDC-to-Tableflow.
+
+2. **If multi-event topics already exist**, split them before the Flink/Tableflow stage:
+   - Create a Flink SQL job per event type that filters and routes to separate target topics
+   - Each target topic gets its own schema and can be used with Tableflow normally
+   - For schemaless multi-event topics, use the raw BYTES approach (Option 3 above) with JSON functions to filter by event type:
+     ```sql
+     -- Route events by type to separate typed target tables
+     INSERT INTO target_orders
+     SELECT JSON_VALUE(val, '$.order_id' RETURNING INT), ...
+     FROM inferred_raw
+     WHERE JSON_VALUE(val, '$.event_type') = 'order';
+     ```
+
+3. **If migrating from `RecordNameStrategy` / `TopicRecordNameStrategy`**, the long-term fix is to re-route events to separate topics with `TopicNameStrategy`. Short-term, use Flink to split and re-serialize as described above.
+
+**Recommendation:** Keep `TopicNameStrategy` (default) and one-topic-per-table for CDC pipelines targeting Tableflow.
 
 ---
 

--- a/skills/confluent-cloud-cdc-tableflow/references/database-prerequisites.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/database-prerequisites.md
@@ -4,71 +4,24 @@ Each database requires specific configuration to support Change Data Capture. Th
 
 ## PostgreSQL CDC Prerequisites
 
-### Required PostgreSQL Configuration
+### Required Configuration (postgresql.conf, restart required)
 
-**WAL Level:**
-```sql
--- Check current WAL level
-SHOW wal_level;
-
--- Must be 'logical'
--- Set in postgresql.conf:
+```
 wal_level = logical
+max_replication_slots = 4    # at least 1 per connector
+max_wal_senders = 4          # at least 1 per connector
 ```
 
-**Replication Slots:**
-```sql
--- Check max_replication_slots
-SHOW max_replication_slots;
-
--- Should be at least 1 per connector (recommend 4+)
--- Set in postgresql.conf:
-max_replication_slots = 4
-```
-
-**WAL Senders:**
-```sql
--- Check max_wal_senders
-SHOW max_wal_senders;
-
--- Should be at least 1 per connector (recommend 4+)
--- Set in postgresql.conf:
-max_wal_senders = 4
-```
-
-**Restart Required:**
-After changing these settings, PostgreSQL must be restarted.
-
-### Required Permissions
-
-The connector user needs these permissions:
+### Required Permissions & Publication
 
 ```sql
--- Grant replication privilege
 ALTER USER <connector_user> WITH REPLICATION;
-
--- Grant permissions on database
 GRANT CONNECT ON DATABASE <database> TO <connector_user>;
-
--- Grant schema permissions
 GRANT USAGE ON SCHEMA <schema> TO <connector_user>;
-
--- Grant table permissions
 GRANT SELECT ON ALL TABLES IN SCHEMA <schema> TO <connector_user>;
+ALTER DEFAULT PRIVILEGES IN SCHEMA <schema> GRANT SELECT ON TABLES TO <connector_user>;
 
--- Grant permissions for future tables
-ALTER DEFAULT PRIVILEGES IN SCHEMA <schema>
-  GRANT SELECT ON TABLES TO <connector_user>;
-```
-
-### Publication Setup (PostgreSQL 10+)
-
-```sql
--- Create publication for tables to capture
 CREATE PUBLICATION dbz_publication FOR TABLE table1, table2, table3;
-
--- Or for all tables in a schema
-CREATE PUBLICATION dbz_publication FOR ALL TABLES;
 ```
 
 ### Cloud-Specific Notes
@@ -88,88 +41,65 @@ CREATE PUBLICATION dbz_publication FOR ALL TABLES;
 - Set `max_replication_slots >= 4`
 - Restart server
 
+### Replication Slot Cleanup
+
+**Critical:** When a CDC connector is deleted, its named replication slot is NOT automatically dropped. Orphaned replication slots hold WAL segments indefinitely, causing disk usage to grow until the database runs out of storage.
+
+**After deleting a connector**, always clean up the replication slot:
+
+```sql
+-- List active replication slots
+SELECT slot_name, active, pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+FROM pg_replication_slots;
+
+-- Drop the orphaned slot (only when 'active' = false)
+SELECT pg_drop_replication_slot('debezium_slot');
+```
+
+**Monitor for orphaned slots** — set up an alert if `pg_wal_lsn_diff` grows beyond a threshold (e.g., 1 GB) for any inactive slot. On managed services like RDS, orphaned slots can fill the allocated storage and cause the instance to become read-only.
+
 ### Verification
 
 ```sql
--- Verify WAL level
-SELECT name, setting FROM pg_settings WHERE name = 'wal_level';
-
--- Check replication slots
-SELECT * FROM pg_replication_slots;
-
--- Test publication
-SELECT * FROM pg_publication;
+SHOW wal_level;                          -- must be 'logical'
+SHOW max_replication_slots;              -- must be >= 1
 SELECT * FROM pg_publication_tables WHERE pubname = 'dbz_publication';
+SELECT slot_name, active, pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal FROM pg_replication_slots;
 ```
 
-**References:**
-- Debezium PostgreSQL: https://debezium.io/documentation/reference/2.4/connectors/postgresql.html#postgresql-in-the-cloud
-- Confluent PostgreSQL CDC V2: https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-debezium/cc-postgresql-cdc-source-v2-debezium.html
+### Documentation
+
+- **Confluent PostgreSQL CDC Source V2 connector:** https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-debezium/cc-postgresql-cdc-source-v2-debezium.html
+- **Confluent PostgreSQL CDC prerequisites:** https://docs.confluent.io/cloud/current/connectors/cc-postgresql-cdc-source-v2-debezium/prereqs-validation.html
+- **Debezium PostgreSQL connector:** https://debezium.io/documentation/reference/2.4/connectors/postgresql.html
+- **AWS RDS PostgreSQL:** https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_PostgreSQL.html
 
 ---
 
 ## MySQL CDC Prerequisites
 
-### Required MySQL Configuration
+### Required Configuration (my.cnf, restart required)
 
-**Binary Logging:**
-```sql
--- Check if binary logging is enabled
-SHOW VARIABLES LIKE 'log_bin';
-
--- Check binlog format (must be ROW)
-SHOW VARIABLES LIKE 'binlog_format';
-
--- Set in my.cnf or my.ini:
+```
 log_bin = mysql-bin
 binlog_format = ROW
 binlog_row_image = FULL
+gtid_mode = ON                       # recommended
+enforce_gtid_consistency = ON        # recommended
+binlog_expire_logs_seconds = 604800  # 7 days minimum
 ```
-
-**GTID Mode (Recommended):**
-```sql
--- Check GTID status
-SHOW VARIABLES LIKE 'gtid_mode';
-SHOW VARIABLES LIKE 'enforce_gtid_consistency';
-
--- Enable in my.cnf:
-gtid_mode = ON
-enforce_gtid_consistency = ON
-```
-
-**Binary Log Retention:**
-```sql
--- Check retention (in seconds)
-SHOW VARIABLES LIKE 'binlog_expire_logs_seconds';
-
--- Set retention to at least 7 days (604800 seconds)
--- In my.cnf:
-binlog_expire_logs_seconds = 604800
-```
-
-**Restart Required:**
-After changing these settings, MySQL must be restarted.
 
 ### Required Permissions
 
 ```sql
--- Create dedicated CDC user
 CREATE USER '<connector_user>'@'%' IDENTIFIED BY '<password>';
-
--- Grant replication privileges
-GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT
-  ON *.* TO '<connector_user>'@'%';
-
--- Grant LOCK TABLES (required for managed MySQL — see note below)
+GRANT SELECT, RELOAD, SHOW DATABASES, REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO '<connector_user>'@'%';
 GRANT LOCK TABLES ON <database>.* TO '<connector_user>'@'%';
-
--- Grant permissions on specific database/tables
 GRANT SELECT ON <database>.* TO '<connector_user>'@'%';
-
 FLUSH PRIVILEGES;
 ```
 
-**Why LOCK TABLES is needed on managed MySQL:** Debezium's default snapshot behavior tries `FLUSH TABLES WITH READ LOCK` first (a global read lock requiring the `SUPER` or `RELOAD` privilege). On self-managed MySQL where the user has `SUPER`, this works fine. But managed services (RDS, Aurora, Cloud SQL, Azure MySQL) don't grant `SUPER`, so the global lock fails and Debezium falls back to per-table `LOCK TABLES` — which requires the `LOCK TABLES` privilege explicitly. Without it, the connector fails during the initial snapshot with: *"The database user does not have the 'LOCK TABLES' privilege required to obtain a consistent snapshot."*
+**LOCK TABLES on managed MySQL:** Managed services (RDS, Aurora, Cloud SQL, Azure) don't grant `SUPER`, so Debezium can't use `FLUSH TABLES WITH READ LOCK` and falls back to per-table `LOCK TABLES`. Without this grant, the connector fails during snapshot.
 
 ### Cloud-Specific Notes
 
@@ -195,82 +125,42 @@ FLUSH PRIVILEGES;
 ### Verification
 
 ```sql
--- Verify binlog is enabled and ROW format
-SHOW VARIABLES LIKE 'log_bin';
-SHOW VARIABLES LIKE 'binlog_format';
-SHOW VARIABLES LIKE 'binlog_row_image';
-
--- Check GTID mode
-SHOW VARIABLES LIKE 'gtid_mode';
-
--- List binary logs
-SHOW BINARY LOGS;
-
--- Verify user permissions
+SHOW VARIABLES LIKE 'log_bin';           -- must be ON
+SHOW VARIABLES LIKE 'binlog_format';     -- must be ROW
+SHOW VARIABLES LIKE 'gtid_mode';         -- should be ON
 SHOW GRANTS FOR '<connector_user>'@'%';
 ```
 
-**References:**
-- Debezium MySQL: https://debezium.io/documentation/reference/2.4/connectors/mysql.html
-- Confluent MySQL CDC V2: https://docs.confluent.io/cloud/current/connectors/cc-mysql-cdc-source-v2-debezium/cc-mysql-cdc-source-v2-debezium.html
+### Documentation
+
+- **Confluent MySQL CDC Source V2 connector:** https://docs.confluent.io/cloud/current/connectors/cc-mysql-cdc-source-v2-debezium/cc-mysql-cdc-source-v2-debezium.html
+- **Confluent MySQL CDC prerequisites:** https://docs.confluent.io/cloud/current/connectors/cc-mysql-cdc-source-v2-debezium/prereqs-validation.html
+- **Debezium MySQL connector:** https://debezium.io/documentation/reference/2.4/connectors/mysql.html
+- **AWS RDS MySQL:** https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_MySQL.html
 
 ---
 
 ## SQL Server CDC Prerequisites
 
-### Enable CDC on Database
-
-```sql
--- Check if CDC is enabled on database
-SELECT is_cdc_enabled FROM sys.databases
-WHERE name = '<database_name>';
-
--- Enable CDC on database
-USE <database_name>;
-EXEC sys.sp_cdc_enable_db;
-```
-
-### Enable CDC on Tables
-
-```sql
--- Enable CDC for specific table
-USE <database_name>;
-EXEC sys.sp_cdc_enable_table
-  @source_schema = N'dbo',
-  @source_name   = N'<table_name>',
-  @role_name     = NULL,
-  @supports_net_changes = 1;
-
--- Verify CDC is enabled for table
-SELECT name, is_tracked_by_cdc
-FROM sys.tables
-WHERE name = '<table_name>';
-```
-
-### SQL Server Agent
+### Enable CDC and Permissions
 
 **Critical:** SQL Server Agent must be running for CDC to work.
 
 ```sql
--- Check SQL Server Agent status (in Management Studio or via xp_servicecontrol)
-EXEC xp_servicecontrol 'QueryState', 'SQLServerAGENT';
-```
-
-### Required Permissions
-
-```sql
--- Create login and user
-CREATE LOGIN <connector_user> WITH PASSWORD = '<password>';
+-- Enable CDC on database
 USE <database_name>;
-CREATE USER <connector_user> FOR LOGIN <connector_user>;
+EXEC sys.sp_cdc_enable_db;
 
--- Grant permissions
+-- Enable CDC on each table
+EXEC sys.sp_cdc_enable_table @source_schema = N'dbo', @source_name = N'<table_name>', @role_name = NULL, @supports_net_changes = 1;
+
+-- Create connector user with permissions
+CREATE LOGIN <connector_user> WITH PASSWORD = '<password>';
+CREATE USER <connector_user> FOR LOGIN <connector_user>;
 GRANT SELECT ON SCHEMA :: dbo TO <connector_user>;
+GRANT SELECT ON SCHEMA :: cdc TO <connector_user>;
 GRANT VIEW DATABASE STATE TO <connector_user>;
 EXEC sp_addrolemember N'db_datareader', N'<connector_user>';
-
--- Grant access to CDC tables
-GRANT SELECT ON SCHEMA :: cdc TO <connector_user>;
 ```
 
 ### Cloud-Specific Notes
@@ -291,78 +181,135 @@ GRANT SELECT ON SCHEMA :: cdc TO <connector_user>;
 ### Verification
 
 ```sql
--- Check database CDC status
 SELECT name, is_cdc_enabled FROM sys.databases;
-
--- List CDC-enabled tables
-SELECT SCHEMA_NAME(schema_id) + '.' + name AS table_name, is_tracked_by_cdc
-FROM sys.tables
-WHERE is_tracked_by_cdc = 1;
-
--- View CDC capture instances
-SELECT * FROM cdc.change_tables;
-
--- Check CDC jobs are running
+SELECT name, is_tracked_by_cdc FROM sys.tables WHERE is_tracked_by_cdc = 1;
 EXEC sys.sp_cdc_help_jobs;
 ```
 
-**References:**
-- Debezium SQL Server: https://debezium.io/documentation/reference/2.4/connectors/sqlserver.html
-- Confluent SQL Server CDC V2: https://docs.confluent.io/cloud/current/connectors/cc-microsoft-sql-server-cdc-source-v2-debezium/cc-microsoft-sql-server-cdc-source-v2-debezium.html
+### Documentation
+
+- **Confluent SQL Server CDC Source V2 connector:** https://docs.confluent.io/cloud/current/connectors/cc-sqlserver-cdc-source-v2-debezium/cc-sqlserver-cdc-source-v2-debezium.html
+- **Confluent SQL Server CDC prerequisites:** https://docs.confluent.io/cloud/current/connectors/cc-sqlserver-cdc-source-v2-debezium/prereqs-validation.html
+- **Debezium SQL Server connector:** https://debezium.io/documentation/reference/2.4/connectors/sqlserver.html
+- **AWS RDS SQL Server:** https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html
+- **RDS SQL Server CDC:** https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.SQLServer.CommonDBATasks.CDC.html
 
 ---
 
-## Oracle CDC Prerequisites
+## Oracle XStream CDC Prerequisites
 
-### Archive Log Mode
+**Connector class:** `OracleXStreamSource`
 
-Oracle must be in ARCHIVELOG mode:
+**Supported platforms:**
+- Self-managed Oracle Database 19c+
+- Amazon RDS for Oracle (non-CDB architecture only)
 
+**NOT supported:**
+- Oracle Autonomous Databases
+- Oracle Standby databases (Data Guard)
+- Downstream Capture configurations
+- CDB (Container Database) architecture on RDS
+
+**Licensing:** Requires a valid Confluent license for Oracle XStream Out.
+
+### Documentation
+
+- **Confluent Oracle XStream CDC Source connector:** https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-cdc-source/cc-oracle-xstream-cdc-source.html
+- **Confluent Oracle XStream CDC prerequisites:** https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-cdc-source/prereqs-validation.html
+- **Working with Amazon RDS for Oracle:** https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-cdc-source/prereqs-validation.html#working-with-amazon-rds-for-oracle
+- **AWS RDS Oracle:** https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Oracle.html
+- **Oracle XStream concepts:** https://docs.oracle.com/en/database/oracle/oracle-database/19/xstrm/introduction-to-xstream.html
+
+### Step 1: Enable GoldenGate Replication
+
+XStream requires GoldenGate replication to be enabled at the database level.
+
+**Standard Oracle (non-RDS):**
 ```sql
--- Check archive log mode
-SELECT log_mode FROM v$database;
+-- Connect as SYSDBA
+ALTER SYSTEM SET enable_goldengate_replication=TRUE SCOPE=BOTH;
+```
 
--- Enable archive log mode (requires restart)
+**Amazon RDS for Oracle:**
+- Modify the DB parameter group: set `enable_goldengate_replication` to `TRUE`
+- Apply the parameter group changes and **reboot the RDS instance**
+
+**Verify:**
+```sql
+SELECT VALUE FROM V$PARAMETER WHERE NAME = 'enable_goldengate_replication';
+-- Must return TRUE
+```
+
+### Step 2: Enable ARCHIVELOG Mode
+
+**Standard Oracle (non-RDS):**
+```sql
+-- Check current mode
+SELECT LOG_MODE FROM V$DATABASE;
+
+-- Enable if not already ARCHIVELOG (requires restart)
 SHUTDOWN IMMEDIATE;
 STARTUP MOUNT;
 ALTER DATABASE ARCHIVELOG;
 ALTER DATABASE OPEN;
 ```
 
-### Supplemental Logging
+**Amazon RDS for Oracle:**
+- ARCHIVELOG mode is enabled automatically when **automated backups** are turned on
+- Ensure automated backups are enabled in the RDS console (backup retention period > 0)
 
+### Step 3: Configure Supplemental Logging
+
+Supplemental logging ensures all column values are included in the redo log for CDC.
+
+**Minimal supplemental logging (required):**
 ```sql
--- Enable minimal supplemental logging at database level
 ALTER DATABASE ADD SUPPLEMENTAL LOG DATA;
-
--- Enable identification key logging
-ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (PRIMARY KEY) COLUMNS;
-
--- For tables without primary keys, enable all columns
-ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
-
--- Verify supplemental logging
-SELECT supplemental_log_data_min, supplemental_log_data_pk
-FROM v$database;
 ```
 
-### Table-Level Supplemental Logging
-
+**Table-level supplemental logging (recommended — captures all columns):**
 ```sql
--- For each table to capture
 ALTER TABLE <schema>.<table> ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
 ```
 
-### XStream Configuration
+**Alternative — database-level (captures all columns for all tables):**
+```sql
+ALTER DATABASE ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+```
 
-For Oracle XStream CDC connector:
+**Amazon RDS for Oracle:**
+```sql
+-- Enable minimal supplemental logging
+exec rdsadmin.rdsadmin_util.alter_supplemental_logging('ADD');
+
+-- Enable ALL column supplemental logging (database-level)
+exec rdsadmin.rdsadmin_util.alter_supplemental_logging('ADD','ALL');
+
+-- Or table-level (same SQL as standard Oracle)
+ALTER TABLE <schema>.<table> ADD SUPPLEMENTAL LOG DATA (ALL) COLUMNS;
+```
+
+**Verify:**
+```sql
+SELECT SUPPLEMENTAL_LOG_DATA_MIN, SUPPLEMENTAL_LOG_DATA_ALL FROM V$DATABASE;
+-- SUPPLEMENTAL_LOG_DATA_MIN should be YES
+
+-- For table-level verification
+SELECT * FROM ALL_LOG_GROUPS
+WHERE LOG_GROUP_TYPE = 'ALL COLUMN LOGGING'
+  AND OWNER = '<schema>'
+  AND TABLE_NAME = '<table>';
+```
+
+### Step 4: Create XStream Admin User and Grant Privileges
 
 ```sql
--- Create XStream admin user
+-- Create the XStream admin user
 CREATE USER xstream_admin IDENTIFIED BY <password>;
 GRANT CREATE SESSION TO xstream_admin;
+GRANT SET CONTAINER TO xstream_admin;
 
--- Grant XStream privileges
+-- Grant XStream admin privileges
 BEGIN
   DBMS_XSTREAM_AUTH.GRANT_ADMIN_PRIVILEGE(
     grantee => 'xstream_admin',
@@ -371,52 +318,99 @@ BEGIN
   );
 END;
 /
+```
 
--- Create outbound server
+### Step 5: Create XStream Outbound Server
+
+The outbound server name must match the connector's `database.out.server.name` property.
+
+```sql
+-- Connect as the XStream admin user
 BEGIN
   DBMS_XSTREAM_ADM.CREATE_OUTBOUND(
     server_name => 'dbz_outbound',
-    table_names => '<schema>.<table>',
-    source_database => '<database>'
+    table_names => '<SCHEMA>.<TABLE1>,<SCHEMA>.<TABLE2>',
+    source_database => '<database_name>'
   );
 END;
 /
 ```
 
-### Required Permissions
+**Important:** The `table_names` parameter controls which tables are captured. If you need to add more tables later, you must drop and recreate the outbound server, or use `DBMS_XSTREAM_ADM.ALTER_OUTBOUND` to add tables.
+
+### Step 6: Create Connector User and Grant Permissions
+
+The connector user is the user specified in the connector's `database.user` property — this is the user the connector authenticates as to read XStream changes.
 
 ```sql
 -- Create connector user
 CREATE USER <connector_user> IDENTIFIED BY <password>;
 
--- Grant session and basic permissions
+-- Grant required permissions
 GRANT CREATE SESSION TO <connector_user>;
 GRANT SET CONTAINER TO <connector_user>;
 GRANT SELECT ON V_$DATABASE TO <connector_user>;
+GRANT SELECT ON V_$INSTANCE TO <connector_user>;
 GRANT FLASHBACK ANY TABLE TO <connector_user>;
+GRANT SELECT_CATALOG_ROLE TO <connector_user>;
+GRANT EXECUTE_CATALOG_ROLE TO <connector_user>;
+GRANT SELECT ANY TABLE TO <connector_user>;
+GRANT LOCK ANY TABLE TO <connector_user>;
 
--- Grant table permissions
-GRANT SELECT ON <schema>.<table> TO <connector_user>;
+-- Grant XStream connect privilege to the connector user for the outbound server
+BEGIN
+  DBMS_XSTREAM_ADM.ALTER_OUTBOUND(
+    server_name => 'dbz_outbound',
+    connect_user => '<connector_user>'
+  );
+END;
+/
 ```
 
-### Verification
+### Step 7: Verify Complete Setup
 
 ```sql
--- Check archive log mode
-SELECT log_mode FROM v$database;
+-- 1. GoldenGate replication enabled
+SELECT VALUE FROM V$PARAMETER WHERE NAME = 'enable_goldengate_replication';
+-- Must return TRUE
 
--- Verify supplemental logging
-SELECT supplemental_log_data_min, supplemental_log_data_pk, supplemental_log_data_all
-FROM v$database;
+-- 2. ARCHIVELOG mode
+SELECT LOG_MODE FROM V$DATABASE;
+-- Must return ARCHIVELOG
 
--- Check XStream outbound server
-SELECT server_name, capture_name, connect_user, status
-FROM DBA_XSTREAM_OUTBOUND;
+-- 3. Supplemental logging
+SELECT SUPPLEMENTAL_LOG_DATA_MIN, SUPPLEMENTAL_LOG_DATA_ALL FROM V$DATABASE;
+-- SUPPLEMENTAL_LOG_DATA_MIN should be YES
+
+-- 4. XStream outbound server exists and is running
+SELECT SERVER_NAME, CONNECT_USER, STATUS FROM ALL_XSTREAM_OUTBOUND;
+-- Should show your outbound server with ATTACHED or ENABLED status
+
+-- 5. Table-level supplemental logging (if using table-level)
+SELECT * FROM ALL_LOG_GROUPS
+WHERE LOG_GROUP_TYPE = 'ALL COLUMN LOGGING'
+  AND OWNER = '<schema>'
+  AND TABLE_NAME = '<table>';
 ```
 
-**References:**
-- Debezium Oracle: https://debezium.io/documentation/reference/2.4/connectors/oracle.html
-- Confluent Oracle XStream CDC: https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-source/cc-oracle-xstream-source.html
+### Connector Configuration Reference
+
+After all prerequisites are met, the connector requires these Oracle-specific properties:
+
+| Property | Description | Example |
+|---|---|---|
+| `connector.class` | Must be `OracleXStreamSource` | `OracleXStreamSource` |
+| `database.hostname` | Oracle host | `oracle.example.com` |
+| `database.port` | Oracle listener port | `1521` |
+| `database.user` | Connector user (Step 6) | `cfltuser` |
+| `database.password` | Connector user password | `***` |
+| `database.dbname` | Oracle service name or SID | `ORCL` |
+| `database.service.name` | **Required.** Oracle service name | `ORCL` |
+| `database.out.server.name` | XStream outbound server name (Step 5) | `dbz_outbound` |
+| `database.processor.licenses` | **Required.** Oracle processor license count | `1` |
+| `table.include.list` | Tables to capture (uppercase) | `SCHEMA.TABLE` |
+
+See `references/connector-configs.md` for the full connector configuration template.
 
 ---
 
@@ -443,26 +437,46 @@ aws dynamodb update-table \
 
 ### IAM Permissions
 
-Create IAM user or role with these permissions:
+Create IAM user or role with these permissions. **Critical:** The CDC phase requires write permissions for a KCL-style checkpointing table that the connector creates to track shard leases. Without these write permissions, the snapshot phase will work but CDC streaming will silently fail — no real-time changes will be captured.
 
 ```json
 {
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "DynamoDBReadAndCheckpointing",
       "Effect": "Allow",
       "Action": [
         "dynamodb:DescribeTable",
         "dynamodb:DescribeStream",
+        "dynamodb:DescribeTimeToLive",
+        "dynamodb:DescribeContinuousBackups",
+        "dynamodb:DescribeLimits",
         "dynamodb:GetRecords",
         "dynamodb:GetShardIterator",
         "dynamodb:ListStreams",
-        "dynamodb:ListTables"
+        "dynamodb:ListTables",
+        "dynamodb:ListGlobalTables",
+        "dynamodb:ListTagsOfResource",
+        "dynamodb:Scan",
+        "dynamodb:CreateTable",
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:DeleteTable",
+        "dynamodb:TagResource"
       ],
-      "Resource": [
-        "arn:aws:dynamodb:*:*:table/<table-name>",
-        "arn:aws:dynamodb:*:*:table/<table-name>/stream/*"
-      ]
+      "Resource": "*"
+    },
+    {
+      "Sid": "TagAndCloudWatch",
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "cloudwatch:PutMetricData"
+      ],
+      "Resource": "*"
     }
   ]
 }
@@ -471,29 +485,11 @@ Create IAM user or role with these permissions:
 ### Verification
 
 ```bash
-# Check if streams are enabled
-aws dynamodb describe-table --table-name <table-name> \
-  | jq '.Table.StreamSpecification'
-
-# List streams for table
-aws dynamodb list-streams --table-name <table-name>
+aws dynamodb describe-table --table-name <table-name> | jq '.Table.StreamSpecification'
 ```
 
-**References:**
-- Debezium DynamoDB: https://debezium.io/documentation/reference/2.4/connectors/dynamodb.html
-- Confluent DynamoDB CDC: https://docs.confluent.io/cloud/current/connectors/cc-amazon-dynamodb-source.html
-- AWS DynamoDB Streams: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
+### Documentation
 
----
-
-## General Checklist
-
-Before setting up any CDC connector, verify:
-
-- [ ] Database is configured for CDC (WAL, binlog, archive log, streams)
-- [ ] Database user has appropriate permissions
-- [ ] Network connectivity from Confluent Cloud to database
-- [ ] Firewall rules allow connection
-- [ ] Schema Registry is enabled in Confluent Cloud
-- [ ] Sufficient database resources for CDC overhead
-- [ ] Monitoring in place for replication lag
+- **Confluent DynamoDB CDC Source connector:** https://docs.confluent.io/cloud/current/connectors/cc-amazon-dynamodb-cdc-source.html
+- **DynamoDB Streams:** https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Streams.html
+- **DynamoDB Developer Guide:** https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html

--- a/skills/confluent-cloud-cdc-tableflow/references/flink-sql-patterns.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/flink-sql-patterns.md
@@ -1,28 +1,6 @@
 # Flink SQL Patterns for Debezium CDC in Confluent Cloud
 
-This guide covers Flink SQL patterns for working with Debezium CDC events in Confluent Cloud Flink. In Confluent Cloud, Flink is deeply integrated with Schema Registry and Kafka -- source tables from CDC connectors are auto-discovered, and no explicit connector or format properties are needed in CREATE TABLE statements.
-
----
-
-## Key Principle: Auto-Discovery of CDC Source Tables
-
-When a Debezium CDC connector creates topics with schemas registered in Schema Registry, Confluent Cloud Flink **automatically discovers** those topics as Flink tables. You do NOT need to create source tables manually.
-
-For example, if a CDC connector with `topic.prefix = "postgres-cdc"` captures the `public.customers` table, the topic `postgres-cdc.public.customers` automatically appears as a Flink table:
-
-```sql
--- This table already exists -- no CREATE TABLE needed
--- Reference it with backtick-quoting due to dots in the name:
-SELECT * FROM `postgres-cdc.public.customers` LIMIT 5;
-```
-
-Verify auto-discovered tables with:
-
-```sql
-SHOW TABLES;
-```
-
-If the CDC source table does not appear, the connector may not have produced data yet. Wait 2-5 minutes for the connector to fully provision and produce its initial snapshot.
+CDC source tables are **auto-discovered** from Kafka topics with SR schemas — no manual source table creation needed. Reference them with backtick-quoting: `` `postgres-cdc.public.customers` ``. All patterns work identically with `JSON_SR`, `AVRO`, and `PROTOBUF` formats. If a CDC table doesn't appear in `SHOW TABLES`, the connector may not have produced data yet — wait 2-5 minutes.
 
 ---
 
@@ -32,7 +10,9 @@ Debezium uses specific logical types that map to Flink types differently than yo
 
 | Debezium Logical Type | Flink Column Type | Meaning | Conversion |
 |---|---|---|---|
-| `io.debezium.time.MicroTimestamp` | `BIGINT` | Microseconds since epoch | `TO_TIMESTAMP_LTZ(col / 1000, 3)` |
+| `io.debezium.time.ZonedTimestamp` | `STRING` | ISO 8601 string with timezone (MySQL TIMESTAMP) | No conversion needed — already human-readable |
+| `io.debezium.time.NanoTimestamp` | `BIGINT` | Nanoseconds since epoch (SQL Server DATETIME2) | `TO_TIMESTAMP_LTZ(col / 1000000, 3)` |
+| `io.debezium.time.MicroTimestamp` | `BIGINT` | Microseconds since epoch (Oracle TIMESTAMP) | `TO_TIMESTAMP_LTZ(col / 1000, 3)` |
 | `io.debezium.time.Timestamp` | `BIGINT` | Milliseconds since epoch | `TO_TIMESTAMP_LTZ(col, 3)` |
 | `io.debezium.time.Date` | `INT` | Days since epoch | Use as-is or convert |
 | `io.debezium.time.MicroTime` | `BIGINT` | Microseconds since midnight | Use as-is or convert |
@@ -91,27 +71,9 @@ FROM `postgres-cdc.public.customers`;
 
 ## Pattern 3: Multi-Table Pipeline
 
-When capturing multiple tables, create a target table and INSERT statement for each. Each INSERT runs as a separate continuous Flink statement.
+For each table, create a target table (Pattern 1) and INSERT (Pattern 2). **Each INSERT must be submitted as a separate Flink statement** — they run as independent continuous jobs.
 
 ```sql
--- Target tables (source tables are auto-discovered)
-CREATE TABLE `target_customers` (
-  `id` INT NOT NULL,
-  `name` STRING,
-  `email` STRING,
-  `created_at` TIMESTAMP_LTZ(3),
-  PRIMARY KEY (`id`) NOT ENFORCED
-) WITH ('changelog.mode' = 'upsert');
-
-CREATE TABLE `target_orders` (
-  `order_id` BIGINT NOT NULL,
-  `customer_id` INT,
-  `amount` DECIMAL(10, 2),
-  `order_date` TIMESTAMP_LTZ(3),
-  PRIMARY KEY (`order_id`) NOT ENFORCED
-) WITH ('changelog.mode' = 'upsert');
-
--- INSERT statements (each submitted as a separate Flink statement)
 INSERT INTO `target_customers`
 SELECT `id`, `name`, `email`, TO_TIMESTAMP_LTZ(`created_at` / 1000, 3)
 FROM `postgres-cdc.public.customers`;
@@ -120,8 +82,6 @@ INSERT INTO `target_orders`
 SELECT `order_id`, `customer_id`, `amount`, TO_TIMESTAMP_LTZ(`order_date` / 1000, 3)
 FROM `postgres-cdc.public.orders`;
 ```
-
-**Important:** Each INSERT must be submitted as a separate Flink statement via MCP.
 
 ---
 
@@ -229,25 +189,72 @@ Use `mcp__confluent__create-flink-statement` with:
 - **Problem:** `TO_TIMESTAMP_LTZ()` returns `TIMESTAMP_LTZ(3)`, incompatible with `TIMESTAMP(3)`.
 - **Solution:** Define target columns as `TIMESTAMP_LTZ(3)`.
 
-**Pitfall 5: DECIMAL columns appear as garbled BYTES**
-- **Problem:** DECIMAL/NUMERIC columns show as raw bytes (e.g., `"N\u001f"` instead of `"199.99"`). Flink cannot CAST VARBINARY to DECIMAL.
-- **Solution:** This must be fixed at the connector level, not in Flink. Set `"decimal.handling.mode": "string"` in the Debezium connector config. This outputs decimal values as human-readable strings which Flink can handle directly.
+For connector-level data type issues (DECIMAL garbled bytes, INTERVAL lossy values, binary breaking JSON, Oracle NUMBER structs), see `references/connector-configs.md` Data Type Serialization and `references/troubleshooting.md` Data Quality Issues. These must be fixed at the connector level, not in Flink SQL.
 
-**Pitfall 6: INTERVAL columns produce lossy microsecond values**
-- **Problem:** PostgreSQL `INTERVAL` or Oracle `INTERVAL YEAR TO MONTH` columns arrive as INT64 microseconds, approximating months as 30 days and years as 365.25 days.
-- **Solution:** Set `"interval.handling.mode": "string"` on the connector. Values arrive as ISO 8601 strings (e.g., `P1Y2M3DT4H5M6.78S`).
+---
 
-**Pitfall 7: Binary columns break JSON serialization**
-- **Problem:** BYTEA, VARBINARY, BLOB, or RAW columns serialized as raw bytes produce garbled or inconsistent JSON output.
-- **Solution:** Set `"binary.handling.mode": "base64"` on the connector. Values arrive as base64-encoded strings.
+## Pattern 6: Working with Schemaless Topics (No Schema Registry)
 
-**Pitfall 8: Oracle NUMBER without precision produces struct, not scalar**
-- **Problem:** Oracle `NUMBER` (no precision/scale) and `FLOAT` columns are serialized as `VariableScaleDecimal` — a struct of `{scale: INT32, value: BYTES}`, not a simple value. This breaks differently than regular DECIMAL bytes.
-- **Solution:** Set `"decimal.handling.mode": "string"` on the connector. Converts to human-readable string values.
+When a topic has no schema in SR, Flink cannot auto-discover its structure. The preferred fix is to register a schema in SR or use schema inference — see `references/connector-configs.md` "Handling Topics Without Schema Registry" for all options.
 
-**Pitfall 9: CDC source table not in SHOW TABLES**
-- **Problem:** Connector just created, table not visible yet.
-- **Solution:** Wait 2-5 minutes for connector provisioning. Verify schemas exist via `mcp__confluent__list-schemas`.
+If you need to work with the topic directly in Flink without registering a schema, use the raw BYTES approach:
+
+```sql
+-- Flink infers schemaless topics as raw bytes
+-- Modify to STRING to work with JSON payloads
+ALTER TABLE `raw_topic` MODIFY (`key` STRING, `val` STRING);
+
+-- Extract fields using JSON functions
+INSERT INTO `target_customers`
+SELECT
+  JSON_VALUE(`val`, '$.id' RETURNING INT) AS `id`,
+  JSON_VALUE(`val`, '$.name') AS `name`,
+  JSON_VALUE(`val`, '$.email') AS `email`,
+  TO_TIMESTAMP_LTZ(
+    CAST(JSON_VALUE(`val`, '$.created_at') AS BIGINT) / 1000, 3
+  ) AS `created_at`
+FROM `raw_topic`;
+```
+
+This works for any JSON payload regardless of how it was serialized. It's more fragile than schema-based approaches (no type safety, no schema evolution), but useful for ad-hoc exploration or topics you can't modify.
+
+---
+
+## Pattern 7: Multi-Event Topics
+
+Multi-event topics use `RecordNameStrategy` or `TopicRecordNameStrategy` instead of the default `TopicNameStrategy`, putting multiple schemas on one topic. Flink can't auto-discover these. For a detailed breakdown of each strategy, see `references/connector-configs.md` "Subject Name Strategies".
+
+### Splitting Multi-Event Topics into Typed Target Tables
+
+Use the raw BYTES approach with JSON functions to split by event type:
+
+```sql
+-- Multi-event topic: Flink infers as raw bytes since it can't resolve the schema
+-- Modify to STRING to parse JSON payloads
+ALTER TABLE `shared_events` MODIFY (`key` STRING, `val` STRING);
+
+-- Route order events to a typed target table
+INSERT INTO `target_orders`
+SELECT
+  JSON_VALUE(`val`, '$.order_id' RETURNING INT),
+  JSON_VALUE(`val`, '$.customer_id' RETURNING INT),
+  JSON_VALUE(`val`, '$.amount' RETURNING DOUBLE)
+FROM `shared_events`
+WHERE JSON_VALUE(`val`, '$.event_type') = 'order';
+
+-- Route customer events to a separate typed target table
+INSERT INTO `target_customers`
+SELECT
+  JSON_VALUE(`val`, '$.customer_id' RETURNING INT),
+  JSON_VALUE(`val`, '$.name'),
+  JSON_VALUE(`val`, '$.email')
+FROM `shared_events`
+WHERE JSON_VALUE(`val`, '$.event_type') = 'customer';
+```
+
+Each INSERT runs as a separate continuous Flink job. The target topics each use `TopicNameStrategy` (the default for Flink-created topics), so they have a single schema and work normally with Tableflow.
+
+**Long-term recommendation:** Migrate to `TopicNameStrategy` with one topic per event type for any topics that need to flow into Tableflow.
 
 ---
 

--- a/skills/confluent-cloud-cdc-tableflow/references/rest-api.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/rest-api.md
@@ -1,0 +1,165 @@
+# Confluent Cloud REST API Reference
+
+Use these endpoints when neither the MCP server nor Confluent CLI is available. All management API calls use HTTP Basic Auth with a **Cloud API Key** (created at Settings > API Keys > Add Key > Cloud resource management).
+
+```bash
+# Set once for all commands
+export CC_API_KEY="<cloud-api-key>"
+export CC_API_SECRET="<cloud-api-secret>"
+export CC_AUTH="-u ${CC_API_KEY}:${CC_API_SECRET}"
+```
+
+---
+
+## Base URLs
+
+| Service | Base URL |
+|---|---|
+| Management API | `https://api.confluent.cloud` |
+| Kafka REST | `https://pkc-xxxxx.<region>.<cloud>.confluent.cloud:443` (from cluster `spec.http_endpoint`) |
+| Schema Registry | `https://psrc-xxxxx.<region>.<cloud>.confluent.cloud` (from SR cluster `spec.http_endpoint`) |
+| Flink SQL | `https://flink.<region>.<cloud>.confluent.cloud` (region-specific, lowercase cloud provider) |
+
+---
+
+## Environment & Cluster Discovery
+
+```bash
+# List environments
+curl -s ${CC_AUTH} "https://api.confluent.cloud/org/v2/environments" | jq '.data[] | {id, display_name: .display_name}'
+
+# List clusters in environment
+curl -s ${CC_AUTH} "https://api.confluent.cloud/cmk/v2/clusters?environment=<env-id>" | jq '.data[] | {id, display_name: .spec.display_name, cloud: .spec.cloud, region: .spec.region}'
+
+# Get Schema Registry cluster
+curl -s ${CC_AUTH} "https://api.confluent.cloud/srcm/v2/clusters?environment=<env-id>" | jq '.data[0] | {id, endpoint: .spec.http_endpoint}'
+```
+
+---
+
+## Connector Operations
+
+```bash
+# List connectors
+curl -s ${CC_AUTH} "https://api.confluent.cloud/connect/v1/environments/<env-id>/clusters/<cluster-id>/connectors" | jq .
+
+# Create connector (POST with full config JSON)
+curl -s -X POST ${CC_AUTH} -H "Content-Type: application/json" \
+  "https://api.confluent.cloud/connect/v1/environments/<env-id>/clusters/<cluster-id>/connectors" \
+  -d '{"name": "<connector-name>", "config": { <connector-config> }}'
+
+# Check connector status
+curl -s ${CC_AUTH} \
+  "https://api.confluent.cloud/connect/v1/environments/<env-id>/clusters/<cluster-id>/connectors/<connector-name>/status" | jq '.connector.state, .tasks[].state'
+
+# Delete connector
+curl -s -X DELETE ${CC_AUTH} \
+  "https://api.confluent.cloud/connect/v1/environments/<env-id>/clusters/<cluster-id>/connectors/<connector-name>"
+```
+
+---
+
+## Schema Registry Operations
+
+```bash
+# List subjects
+curl -s ${CC_AUTH} "<sr-endpoint>/subjects" | jq .
+
+# Check global compatibility
+curl -s ${CC_AUTH} "<sr-endpoint>/config" | jq .
+
+# Set per-subject compatibility
+curl -s -X PUT ${CC_AUTH} -H "Content-Type: application/json" \
+  "<sr-endpoint>/config/<subject-name>" \
+  -d '{"compatibility": "FULL_TRANSITIVE"}'
+
+# Register a schema (e.g., JSON schema for a schemaless topic)
+curl -s -X POST ${CC_AUTH} -H "Content-Type: application/vnd.schemaregistry.v1+json" \
+  "<sr-endpoint>/subjects/<topic-name>-value/versions" \
+  -d '{"schemaType": "JSON", "schema": "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"integer\"}}}"}'
+```
+
+---
+
+## Flink Operations
+
+Flink SQL requires an **organization ID** and **principal ID** (user or service account). Get them:
+
+```bash
+# Get your user/principal ID
+curl -s ${CC_AUTH} "https://api.confluent.cloud/iam/v2/users" | jq '.data[0].id'
+
+# Org ID is in the resource_name of any environment response
+curl -s ${CC_AUTH} "https://api.confluent.cloud/org/v2/environments" | jq '.metadata'
+```
+
+```bash
+export FLINK_URL="https://flink.<region>.<cloud>.confluent.cloud"
+export ORG_ID="<org-id>"
+export PRINCIPAL_ID="<user-id-or-sa-id>"
+```
+
+```bash
+# Create Flink compute pool
+curl -s -X POST ${CC_AUTH} -H "Content-Type: application/json" \
+  "https://api.confluent.cloud/fcpm/v2/compute-pools" \
+  -d '{"spec": {"display_name": "<pool-name>", "cloud": "<CLOUD>", "region": "<region>", "max_cfu": 10, "environment": {"id": "<env-id>"}}}'
+
+# Submit a Flink SQL statement
+curl -s -X POST ${CC_AUTH} -H "Content-Type: application/json" \
+  "${FLINK_URL}/sql/v1/organizations/${ORG_ID}/environments/<env-id>/statements" \
+  -d '{
+    "name": "<statement-name>",
+    "spec": {
+      "statement": "<SQL>",
+      "compute_pool": {"id": "<pool-id>"},
+      "principal": {"id": "'"${PRINCIPAL_ID}"'"},
+      "properties": {
+        "sql.current-catalog": "<environment-display-name>",
+        "sql.current-database": "<cluster-display-name>"
+      }
+    }
+  }'
+
+# Read statement status/results
+curl -s ${CC_AUTH} \
+  "${FLINK_URL}/sql/v1/organizations/${ORG_ID}/environments/<env-id>/statements/<statement-name>" | jq '.status'
+
+# Delete a Flink statement
+curl -s -X DELETE ${CC_AUTH} \
+  "${FLINK_URL}/sql/v1/organizations/${ORG_ID}/environments/<env-id>/statements/<statement-name>"
+```
+
+---
+
+## Tableflow Operations
+
+```bash
+# Enable Tableflow (POST). Storage: {"kind": "Managed"} or {"kind": "BYOB", "bucket_name": "<bucket>", "provider_integration": {"id": "<cspi-id>"}}
+curl -s -X POST ${CC_AUTH} -H "Content-Type: application/json" \
+  "https://api.confluent.cloud/tableflow/v1/tableflow-topics" \
+  -d '{"display_name": "<topic>", "topic_name": "<topic>", "environment": {"id": "<env-id>"}, "kafka_cluster": {"id": "<cluster-id>"}, "storage": {"kind": "Managed"}, "table_formats": ["ICEBERG"], "config": {"record_failure_strategy": "SUSPEND", "retention_ms": "6048000000"}}'
+
+# List / Describe / Disable
+curl -s ${CC_AUTH} "https://api.confluent.cloud/tableflow/v1/tableflow-topics?environment=<env-id>&spec.kafka_cluster=<cluster-id>" | jq '.data[] | {name: .display_name, status: .status.phase}'
+curl -s ${CC_AUTH} "https://api.confluent.cloud/tableflow/v1/tableflow-topics/<id>" | jq .
+curl -s -X DELETE ${CC_AUTH} "https://api.confluent.cloud/tableflow/v1/tableflow-topics/<id>"
+```
+
+---
+
+## Topic Operations
+
+```bash
+# List topics (uses Kafka cluster API key, not Cloud API key)
+curl -s -u "<kafka-api-key>:<kafka-api-secret>" \
+  "<cluster-rest-endpoint>/kafka/v3/clusters/<cluster-id>/topics" | jq '.data[].topic_name'
+```
+
+---
+
+## Notes
+
+- **Cloud API Key** for management (connectors, Flink, Tableflow, SR). **Kafka API Key** for data-plane (topics, produce, consume).
+- **Flink** requires org ID + principal ID (not needed for MCP/CLI). Base URL is region-specific with lowercase cloud provider.
+- Full API reference: https://docs.confluent.io/cloud/current/api.html

--- a/skills/confluent-cloud-cdc-tableflow/references/troubleshooting.md
+++ b/skills/confluent-cloud-cdc-tableflow/references/troubleshooting.md
@@ -123,7 +123,7 @@ This guide covers common issues when setting up and running CDC pipelines with D
 
 **Symptom:** Connector fails during initial snapshot with: *"The database user does not have the 'LOCK TABLES' privilege required to obtain a consistent snapshot by preventing concurrent writes to tables."*
 
-**Cause:** This happens on all managed MySQL services (AWS RDS/Aurora, Google Cloud SQL, Azure Database for MySQL). Debezium first tries `FLUSH TABLES WITH READ LOCK` (requires `SUPER`), but managed services don't grant `SUPER`. Debezium then falls back to per-table `LOCK TABLES`, which requires an explicit `LOCK TABLES` grant. On self-managed MySQL where the user has `SUPER`, this error doesn't occur because the global lock succeeds.
+**Cause:** Managed MySQL services (RDS/Aurora, Cloud SQL, Azure) don't grant `SUPER`, so Debezium falls back to per-table `LOCK TABLES` which needs an explicit grant. See `references/database-prerequisites.md` MySQL section for details.
 
 **Solution:**
 ```sql
@@ -132,6 +132,69 @@ FLUSH PRIVILEGES;
 ```
 
 Then restart or recreate the connector.
+
+### Snapshot Takes Too Long / Unclear if Pipeline is Broken
+
+**Symptom:** After creating the connector with `snapshot.mode: initial` on a large table, no data appears in the target topic for hours. Unclear whether the snapshot is still running or the pipeline is broken.
+
+**Cause:** Initial snapshots on large tables (100M+ rows) can take hours or days. The skill's Phase 4 verification can't distinguish "waiting for snapshot" from "broken pipeline."
+
+**Diagnosis:**
+1. Check if the connector has tasks assigned (provisioned):
+   ```
+   mcp__confluent__read-connector(connectorName, environmentId, clusterId)
+   ```
+   If `tasks: [{...}]` → connector is provisioned and likely running the snapshot.
+
+2. Check if schemas have been registered (snapshot has started producing):
+   ```
+   mcp__confluent__list-schemas(subjectPrefix: "<topic-prefix>")
+   ```
+   Schemas appearing means the connector has started producing. No schemas after 5+ minutes with tasks assigned = broken.
+
+3. Monitor the source topic for growing message count — in Confluent Cloud UI, check the topic's "Messages In" metric. A steady stream means the snapshot is progressing.
+
+4. Check the source database for active replication connections:
+   ```sql
+   -- PostgreSQL: check active replication slots
+   SELECT slot_name, active, confirmed_flush_lsn FROM pg_replication_slots;
+
+   -- MySQL: check active binlog connections
+   SHOW PROCESSLIST;
+   ```
+
+**Mitigation for initial validation:**
+Use `snapshot.mode: schema_only` to validate the pipeline end-to-end without waiting for the full snapshot. Once confirmed working, delete the connector and recreate with `snapshot.mode: initial`.
+
+### CDC Connector Broken After Kafka Topic Deletion
+
+**Symptom:** After deleting a CDC source Kafka topic (e.g., `mysql-cdc.cdctest.customers`) while the connector was running, the connector enters a failure loop and cannot recover.
+
+**Cause:** The connector tracks its position (offsets, binlog position, LSN, etc.) relative to the Kafka topic. When the topic is deleted, the connector loses its state and cannot resume or re-snapshot automatically.
+
+**Solution:** Delete the connector entirely and recreate it from scratch. The new connector will perform a fresh initial snapshot. **Never delete CDC source Kafka topics while the connector is running.** Always delete the connector first, then clean up topics.
+
+### DynamoDB CDC: Snapshot Works but CDC Streaming Silently Fails
+
+**Symptom:** The connector completes the initial snapshot (records with `sync_mode: SNAPSHOT` appear in the Kafka topic), but subsequent DML changes never appear. The connector shows as RUNNING with a task assigned — no errors visible.
+
+**Cause:** The IAM user is missing write permissions needed for the CDC checkpointing table. The DynamoDB CDC connector uses a KCL-style DynamoDB table to track shard leases during the CDC phase. Without `CreateTable`, `PutItem`, `GetItem`, `UpdateItem`, `DeleteItem` permissions, the connector cannot create or update this table, so the CDC phase cannot track its position in the stream.
+
+**Diagnosis:**
+1. Check the source Kafka topic — if only `sync_mode: SNAPSHOT` records exist and no `sync_mode: CDC` records appear after 5+ minutes, the CDC phase is not working
+2. Check the IAM policy for the connector's IAM user — it likely only has read permissions (`Scan`, `GetRecords`, `GetShardIterator`, etc.) but is missing write permissions
+
+**Solution:** Update the IAM policy to include all required permissions for both reading DynamoDB Streams and writing to the checkpointing table. See `references/database-prerequisites.md` "DynamoDB CDC Prerequisites" for the complete IAM policy. After updating the IAM policy, delete and recreate the connector.
+
+Also ensure the connector config includes these explicit properties:
+```json
+{
+  "dynamodb.table.discovery.mode": "INCLUDELIST",
+  "dynamodb.table.sync.mode": "SNAPSHOT_CDC",
+  "dynamodb.cdc.max.poll.records": "5000",
+  "dynamodb.snapshot.max.poll.records": "1000"
+}
+```
 
 ### Connector Runs but No Messages
 
@@ -147,6 +210,24 @@ mcp__confluent__search-topics-by-name(topicName: "<topic-prefix>")
 1. Initial snapshot still in progress (wait a few more minutes)
 2. `table.include.list` filter excludes all tables (check case sensitivity)
 3. `snapshot.mode = "never"` and no recent database changes
+
+### Orphaned PostgreSQL Replication Slot After Connector Deletion
+
+**Symptom:** After deleting a PostgreSQL CDC connector, database disk usage grows steadily. Eventually the database may become read-only (on managed services like RDS).
+
+**Cause:** Deleting the connector does NOT drop the replication slot. The orphaned slot holds WAL segments indefinitely.
+
+**Solution:**
+```sql
+-- Check for orphaned slots (active = false)
+SELECT slot_name, active, pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn)) AS retained_wal
+FROM pg_replication_slots;
+
+-- Drop the orphaned slot
+SELECT pg_drop_replication_slot('debezium_slot');
+```
+
+**Prevention:** Always clean up the replication slot when deleting a PostgreSQL CDC connector. See `references/database-prerequisites.md` for monitoring guidance.
 
 ---
 
@@ -229,7 +310,40 @@ These warnings appear on INSERT statements but don't prevent execution:
 - **Managed** — Confluent manages the S3 storage
 - **BYOB (Bring Your Own Bucket)** — User provides S3 bucket with Provider Integration
 
-**Requirement:** Tableflow requires a **Dedicated** cluster. Basic and Standard clusters do not support Tableflow.
+**Requirement:** Tableflow works across all Confluent Cloud cluster types (Basic, Standard, Enterprise, Dedicated, and Freight).
+
+### Tableflow Suspended: Null Value (Tombstone) on APPEND-Mode Topic
+
+**Symptom:** Tableflow suspends with: *"Tableflow will be suspended because we detected a Kafka record at partition X offset Y with a null value. The changelog mode of this table is APPEND."*
+
+**Cause:** CDC connectors with `tombstones.on.delete=true` produce null-value Kafka records (tombstones) when a row is deleted in the source database. Tableflow in APPEND mode cannot handle null values.
+
+**Solution:** **Never enable Tableflow directly on CDC source topics.** Follow the skill's architecture: use a Flink INSERT job to decode the Debezium envelope into a target topic created with `'changelog.mode' = 'upsert'`, then enable Tableflow on that target topic. The Flink decode layer properly translates DELETE operations into upsert-compatible retract/tombstone messages that Tableflow handles correctly.
+
+**Do NOT try these workarounds — they don't work:**
+- `record_failure_strategy: SKIP` — Does not skip changelog mode violations, only data-level errors.
+- `after.state.only=true` on the connector — Strips the Debezium envelope but tombstones still produce null values. Also, `OracleXStreamSource` does not support this option.
+- Changing `changelog.mode` from APPEND to UPSERT after Tableflow has started — See "Changelog Mode Immutable" below.
+
+### Tableflow Error: Changelog Mode Modified
+
+**Symptom:** *"The changelog mode for this topic has been modified since table materialization began from APPEND to UPSERT. Modifying the changelog mode of an existing table is not supported."*
+
+**Cause:** Tableflow caches the changelog mode at first materialization. The mode was APPEND when Tableflow first read from the topic, and someone subsequently altered the topic's `changelog.mode` property to UPSERT.
+
+**Solution:** The cached mode cannot be changed. You must:
+1. Delete the Tableflow topic
+2. Delete the underlying Kafka topic (this is required because the S3 `table_path` is keyed by topic name — deleting only the Tableflow topic and recreating it reuses the same cached state)
+3. Recreate the Kafka topic with `'changelog.mode' = 'upsert'` set from creation (via Flink CREATE TABLE)
+4. Re-enable Tableflow on the new topic
+
+### Tableflow Error: Incompatible Schema Evolution
+
+**Symptom:** *"Incompatible schema evolution detected. Field changed from nullable to non-nullable at key."*
+
+**Cause:** Multiple changelog mode changes corrupted the Tableflow S3 state. Flip-flopping between APPEND and UPSERT modes causes schema conflicts because the key nullability changes between modes.
+
+**Solution:** Full pipeline reset required — delete the Tableflow topic, the Kafka topic, all associated schemas, and recreate from scratch. See SKILL.md "Pipeline cleanup order matters" for the correct deletion sequence.
 
 ### Tableflow Topic Fails to Activate
 
@@ -241,7 +355,7 @@ These warnings appear on INSERT statements but don't prevent execution:
 
 2. **Storage credentials invalid (BYOB only)** — Check Provider Integration and IAM permissions.
 
-3. **Cluster type** — Must be a Dedicated cluster.
+3. **Cluster type** — Verify Tableflow is available on your cluster tier and region.
 
 ### Tableflow Not Writing Files
 
@@ -290,6 +404,47 @@ mcp__confluent__list-schemas(subjectPrefix: "<topic-prefix>")
 6. Recreate the connector fresh — it will create new topics, register new schemas, and do a clean initial snapshot
 
 **Important:** Simply deleting schemas without deleting the topics does NOT work. The old messages with stale schema IDs remain on the topics and will cause Flink failures.
+
+### Schema Registry Compatibility Rejects New Schema
+
+**Symptom:** Connector halts or fails to register a new schema after a database column is dropped or a type changes.
+
+**Cause:** The default Schema Registry compatibility mode is `BACKWARD`. If Debezium registers a schema with a removed field, `BACKWARD` compatibility rejects it because existing consumers might depend on that field.
+
+**Solution:**
+1. Check current compatibility:
+   ```bash
+   confluent schema-registry config describe --environment <env-id>
+   ```
+2. For CDC subjects, set `FULL_TRANSITIVE` compatibility (allows both forward and backward evolution):
+   ```bash
+   confluent schema-registry config update --subject "<topic-prefix>.<schema>.<table>-value" --compatibility FULL_TRANSITIVE --environment <env-id>
+   ```
+3. If you need to apply this globally for all CDC subjects, update the global default — but be aware this affects non-CDC subjects too.
+
+**Prevention:** Check SR compatibility during Phase 1 (Discovery) before creating the connector.
+
+### Topic Has No Schema — Flink Can't Auto-Discover
+
+**Symptom:** A topic exists and has messages, but doesn't appear in `SHOW TABLES` in Flink.
+
+**Cause:** The topic was produced without a Schema Registry serializer (plain `JSON` / `StringSerializer`), so no schema is registered.
+
+**Solution:** Register a JSON schema in SR (partial schemas work for JSON), use [schema inference](https://docs.confluent.io/cloud/current/sr/schemas-manage.html#infer-a-schema-from-messages), or use Flink's raw BYTES approach. See `references/connector-configs.md` "Handling Topics Without Schema Registry" for all options and `references/flink-sql-patterns.md` Pattern 6 for Flink-specific code.
+
+### Multi-Event Topic — Mixed Schemas on One Topic
+
+**Symptom:** A topic has messages from multiple event types. Flink can't auto-discover it, or some records fail deserialization.
+
+**Cause:** The topic uses `RecordNameStrategy` or `TopicRecordNameStrategy` instead of the default `TopicNameStrategy`. Flink expects one schema per topic.
+
+**Diagnosis:** Check which subjects exist:
+```bash
+confluent schema-registry subject list --environment <env-id> | grep "<topic-name>"
+```
+Subjects like `com.example.Order-value` instead of `<topic-name>-value` indicate `RecordNameStrategy`.
+
+**Solution:** Split into typed target tables using Flink. See `references/flink-sql-patterns.md` Pattern 7 for code and `references/connector-configs.md` "Subject Name Strategies" for strategy details.
 
 ### Schema Evolution
 


### PR DESCRIPTION
## Summary
- **Oracle XStream CDC**: Added full prerequisites (GoldenGate replication, XStream outbound server, admin user grants), connector config template, XStream vs LogMiner comparison, and platform limitations
- **DynamoDB CDC fix**: Added IAM write permissions for KCL checkpointing table — without these, snapshot works but CDC streaming silently fails. Corrected connector property names and added missing config properties
- **Documentation links**: Added Confluent connector docs, prerequisites pages, Debezium docs, and cloud provider references to all 5 database prerequisite sections (PostgreSQL, MySQL, SQL Server, Oracle, DynamoDB)
- **Troubleshooting**: Replaced misleading "slow propagation" section with accurate root cause analysis for DynamoDB CDC failures
- **New reference**: Added REST API reference for Confluent Cloud connector management
- **Flink SQL patterns**: Updated for multi-database CDC scenarios, schemaless topics, and multi-event topic handling

## Test plan
- [ ] Verify Oracle XStream prerequisites match [Confluent docs](https://docs.confluent.io/cloud/current/connectors/cc-oracle-xstream-cdc-source/prereqs-validation.html)
- [ ] Verify DynamoDB IAM policy includes checkpointing table write permissions
- [ ] Verify all documentation links resolve correctly
- [ ] Verify connector config templates have correct property names
- [ ] Run skill against a test environment with each database type

🤖 Generated with [Claude Code](https://claude.com/claude-code)