### PR TITLE
Fix kafka-streams-programming reference paths + import regression check

### DIFF
--- a/skills/kafka-streams-programming/SKILL.md
+++ b/skills/kafka-streams-programming/SKILL.md
@@ -10,9 +10,9 @@ JVM-embedded stream processing library with no separate cluster.
 ## ⚠️ IMPORTANT: Lazy-Load References Only
 **Do NOT read all reference files upfront. Read ONLY what you need, when you need it.**
 
-- User asks "how do I join two topics?" → Read `topology-patterns.md` § Joins Decision Tree only
-- User asks "build me a Kafka Streams app" → Read `build-templates.md` when writing build files, not before
-- User asks "my app is crashing" → Read the specific section in `debugging.md` for that symptom
+- User asks "how do I join two topics?" → Read `references/topology-patterns.md` § Joins Decision Tree only
+- User asks "build me a Kafka Streams app" → Read `references/build-templates.md` when writing build files, not before
+- User asks "my app is crashing" → Read the specific section in `references/debugging.md` for that symptom
 - Most questions need 0-2 reference files total, not all 10
 
 **Never read multiple files preemptively "just in case"**
@@ -45,15 +45,15 @@ Ask (skip if answered): What data (topics)? What output? Relationship between in
 
 ### Step 2: Recommend the Topology Pattern
 
-Match problem to pattern (read `topology-patterns.md` only for the specific pattern needed). Present: why it fits, data flow in plain English, KS primitives involved, tradeoffs/alternatives.
+Match problem to pattern (read `references/topology-patterns.md` only for the specific pattern needed). Present: why it fits, data flow in plain English, KS primitives involved, tradeoffs/alternatives.
 
 ### Key Decision Trees
 
 When needed, read only the relevant section:
-- **Combine topics**: `topology-patterns.md` § Joins Decision Tree
-- **Aggregate over time**: `topology-patterns.md` § Windowing Decision Tree
-- **Enrichment/lookup**: `topology-patterns.md` § Enrichment Patterns
-- **Exactly-once**: `topology-patterns.md` § Exactly-Once (walk through before recommending — at-least-once is simpler if downstream can dedupe)
+- **Combine topics**: `references/topology-patterns.md` § Joins Decision Tree
+- **Aggregate over time**: `references/topology-patterns.md` § Windowing Decision Tree
+- **Enrichment/lookup**: `references/topology-patterns.md` § Enrichment Patterns
+- **Exactly-once**: `references/topology-patterns.md` § Exactly-Once (walk through before recommending — at-least-once is simpler if downstream can dedupe)
 
 After user confirms, go to Build Mode.
 
@@ -71,9 +71,9 @@ Ask (skip if already answered):
 2. **Topics & data flow**: Input/output topics? Schematized? If yes, retrieve schema (don't generate new ones). How do topics connect (joins/lookups/independent)?
 3. **Schema format** (skip if using existing): Avro (default) | Protobuf | JSON Schema
 4. **Build tool**: Gradle (default) | Maven
-5. **Target environment** (REQUIRED): Apache Kafka | Confluent Platform | Confluent Cloud (read `config-baseline.md` when generating config)
-6. **Credentials**: CC needs 2 API keys (Kafka + SR). CP/AK needs bootstrap + SR URLs + auth type (read `cli-commands.md` if needed)
-7. **Deployment sizing**: Partitions? Instances? State size? (read `architecture.md` or `production-hardening.md` § Deployment Sizing if needed)
+5. **Target environment** (REQUIRED): Apache Kafka | Confluent Platform | Confluent Cloud (read `references/config-baseline.md` when generating config)
+6. **Credentials**: CC needs 2 API keys (Kafka + SR). CP/AK needs bootstrap + SR URLs + auth type (read `references/cli-commands.md` if needed)
+7. **Deployment sizing**: Partitions? Instances? State size? (read `references/architecture.md` or `references/production-hardening.md` § Deployment Sizing if needed)
 8. **Test data**: Has data or wants sample data generated?
 
 ### Step 2: Plan Resources
@@ -85,12 +85,12 @@ Present plan: topics to create (source/output/DLQ), schemas to register. Changel
 Generate: project structure, schemas, App.java, TopologyBuilder.java, config, simplelogger.properties, docker-compose (if local), scripts, TopologyTest.java, .env.example, monitoring comments.
 
 **Read references only as needed:**
-- Topology code? → `topology-patterns.md` for the specific pattern
-- Build file structure? → `build-templates.md`
-- Schema syntax? → `schema-patterns.md`
-- Config properties? → `config-baseline.md` for env-specific blocks
+- Topology code? → `references/topology-patterns.md` for the specific pattern
+- Build file structure? → `references/build-templates.md`
+- Schema syntax? → `references/schema-patterns.md`
+- Config properties? → `references/config-baseline.md` for env-specific blocks
 - Scripts? → `scripts/create-topics.sh`, `scripts/teardown.sh`
-- Local dev? → `docker-compose.md`
+- Local dev? → `references/docker-compose.md`
 
 **Gradle**: Run `gradle wrapper --gradle-version 8.12` after creating build files.
 
@@ -100,7 +100,7 @@ If user wants sample data: generate SampleDataProducer.java and `produce` task.
 
 **Trigger:** User says "production"/"prod"/"deploy" or specifies K8s/ECS/Docker Swarm or requests multiple instances.
 
-Add production components (read `production-hardening.md` for details if needed): Logback JSON logging, `logback.xml`, health check endpoint, `Dockerfile` with JVM tuning, KIP-1034 DLQ handler, K8s YAML (if K8s), shadow/fat jar plugin.
+Add production components (read `references/production-hardening.md` for details if needed): Logback JSON logging, `logback.xml`, health check endpoint, `Dockerfile` with JVM tuning, KIP-1034 DLQ handler, K8s YAML (if K8s), shadow/fat jar plugin.
 
 ### Step 5: Walk Through the Code
 
@@ -108,7 +108,7 @@ Explain topology, config choices, how to run, what to monitor. Mention `group.pr
 
 ### Step 6: Verify and Iterate
 
-If user needs verification help, read `verification.md` for checklists and reset procedures.
+If user needs verification help, read `references/verification.md` for checklists and reset procedures.
 
 ---
 
@@ -118,14 +118,14 @@ If user needs verification help, read `verification.md` for checklists and reset
 
 | Symptom | Category | Go to |
 |---|---|---|
-| App crashes on startup | **Startup failure** | `debugging.md` § Startup Failures |
-| App runs but no output / stops processing | **Processing stall** | `debugging.md` § Processing Stalls |
-| Rebalancing loops / constant rebalancing | **Rebalancing** | `debugging.md` § Rebalancing Issues |
-| High lag / slow processing | **Performance** | `debugging.md` § Performance |
-| Deserialization errors / poison pills | **Data quality** | `debugging.md` § Deserialization Errors |
-| State store issues (corruption, growth, recovery) | **State** | `debugging.md` § State Store Issues |
-| Thread failures / `StreamsUncaughtExceptionHandler` | **Thread health** | `debugging.md` § Thread Failures |
-| Memory issues (OOM, high heap, RocksDB) | **Memory** | `debugging.md` § Memory Issues |
+| App crashes on startup | **Startup failure** | `references/debugging.md` § Startup Failures |
+| App runs but no output / stops processing | **Processing stall** | `references/debugging.md` § Processing Stalls |
+| Rebalancing loops / constant rebalancing | **Rebalancing** | `references/debugging.md` § Rebalancing Issues |
+| High lag / slow processing | **Performance** | `references/debugging.md` § Performance |
+| Deserialization errors / poison pills | **Data quality** | `references/debugging.md` § Deserialization Errors |
+| State store issues (corruption, growth, recovery) | **State** | `references/debugging.md` § State Store Issues |
+| Thread failures / `StreamsUncaughtExceptionHandler` | **Thread health** | `references/debugging.md` § Thread Failures |
+| Memory issues (OOM, high heap, RocksDB) | **Memory** | `references/debugging.md` § Memory Issues |
 
 ### Step 2: Gather Context
 
@@ -133,7 +133,7 @@ Ask for: error message, config, runtime environment (local/Docker/K8s/CC), KS/Ja
 
 ### Step 3: Diagnose and Fix
 
-Read the relevant section in `debugging.md` for the identified category. Provide fix with explanation.
+Read the relevant section in `references/debugging.md` for the identified category. Provide fix with explanation.
 
 ---
 
@@ -141,16 +141,16 @@ Read the relevant section in `debugging.md` for the identified category. Provide
 
 Non-negotiable defaults. Apply all. Read reference files only if you need implementation details.
 
-1. **Schematized data**: SR serdes (`SpecificAvroSerde`, `KafkaProtobufSerde`, `KafkaJsonSchemaSerde`). Set `schema.registry.url`, `default.key.serde`, `default.value.serde`. JSON Schema: set `json.value.type`. Protobuf: set `specific.protobuf.value.type` (config-baseline.md)
+1. **Schematized data**: SR serdes (`SpecificAvroSerde`, `KafkaProtobufSerde`, `KafkaJsonSchemaSerde`). Set `schema.registry.url`, `default.key.serde`, `default.value.serde`. JSON Schema: set `json.value.type`. Protobuf: set `specific.protobuf.value.type` (references/config-baseline.md)
 2. **Versions**: KS 4.x / CP 8.x, Java 17+
-3. **KIP-1071**: `group.protocol=streams` (default). Remove if `UnsupportedVersionException`. Unsupported: static membership, regex topics, standby replicas, warm-up replicas (topology-patterns.md § Assignment Strategy)
-4. **Four-tier error handling**: `DeserializationExceptionHandler`, `ProcessingExceptionHandler` (KIP-1034), `ProductionExceptionHandler`, `StreamsUncaughtExceptionHandler`. Use MaxFailures pattern for uncaught (production-hardening.md § Error Handling)
+3. **KIP-1071**: `group.protocol=streams` (default). Remove if `UnsupportedVersionException`. Unsupported: static membership, regex topics, standby replicas, warm-up replicas (references/topology-patterns.md § Assignment Strategy)
+4. **Four-tier error handling**: `DeserializationExceptionHandler`, `ProcessingExceptionHandler` (KIP-1034), `ProductionExceptionHandler`, `StreamsUncaughtExceptionHandler`. Use MaxFailures pattern for uncaught (references/production-hardening.md § Error Handling)
 5. **Explicit naming**: `ensure.explicit.internal.resource.naming=true`
 6. **Graceful shutdown**: Hook with `streams.close(30s)` on SIGTERM/SIGINT
-7. **Monitoring**: `metrics.recording.level=INFO` (config-baseline.md)
-8. **Log verbosity**: Generate `simplelogger.properties` (build-templates.md)
+7. **Monitoring**: `metrics.recording.level=INFO` (references/config-baseline.md)
+8. **Log verbosity**: Generate `simplelogger.properties` (references/build-templates.md)
 9. **Defensive topology**: Guard lambdas in prod (null checks, try/catch). Dev: simpler is fine.
-10. **Schema parity**: Avro/Protobuf/JSON Schema all supported (build-templates.md, schema-patterns.md)
+10. **Schema parity**: Avro/Protobuf/JSON Schema all supported (references/build-templates.md, references/schema-patterns.md)
 11. **Test caching**: TopologyTestDriver tests need `statestore.cache.max.bytes=0` to avoid non-deterministic assertions.
 
 ---
@@ -161,4 +161,4 @@ Non-negotiable defaults. Apply all. Read reference files only if you need implem
 
 ## Reference Files (read on-demand only)
 
-`topology-patterns.md` — design, joins, windows, aggregations | `architecture.md` — internals, sizing | `debugging.md` — troubleshooting | `config-baseline.md` — config | `build-templates.md` — project structure | `schema-patterns.md` — Avro/Protobuf/JSON | `production-hardening.md` — prod setup | `cli-commands.md` — CLI | `docker-compose.md` — local dev | `verification.md` — checklists
+`references/topology-patterns.md` — design, joins, windows, aggregations | `references/architecture.md` — internals, sizing | `references/debugging.md` — troubleshooting | `references/config-baseline.md` — config | `references/build-templates.md` — project structure | `references/schema-patterns.md` — Avro/Protobuf/JSON | `references/production-hardening.md` — prod setup | `references/cli-commands.md` — CLI | `references/docker-compose.md` — local dev | `references/verification.md` — checklists

--- a/skills/kafka-streams-programming/evals/evals.json
+++ b/skills/kafka-streams-programming/evals/evals.json
@@ -14,6 +14,7 @@
         "TopologyBuilder is in a separate class from App for testability",
         "TopologyTest uses mock:// URL scheme for Schema Registry",
         "App.java includes UncaughtExceptionHandler (KIP-671)",
+        "App.java imports StreamsUncaughtExceptionHandler from org.apache.kafka.streams.errors (NOT as a nested class under KafkaStreams — that type does not exist in KS 4.x)",
         "App.java includes graceful shutdown hook with streams.close()",
         "application.properties includes ensure.explicit.internal.resource.naming=true",
         "Avro schemas are in src/main/avro/ (NOT src/main/resources/avro/)"


### PR DESCRIPTION
## Summary

- Fixes [DTX-985](https://confluentinc.atlassian.net/browse/DTX-985) — bug-bash findings on the `kafka-streams-programming` skill.
- `SKILL.md` pointed at reference files as bare filenames (e.g. `` `build-templates.md` ``) but the files live under `references/`. Every session wasted tool calls on failed reads before discovering the real paths.
- When those reads failed, the model fell back to training-data memory — including the hallucinated nested path `KafkaStreams.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse`, which doesn't exist in KS 4.x and broke `./gradlew compileJava` on first generation.

## Changes

- **skills/kafka-streams-programming/SKILL.md** — prefix every `.md` pointer with `references/` (~34 sites across Architect/Build/Debug routing, invariants, and the footer index). No filenames renamed.
- **skills/kafka-streams-programming/evals/evals.json** — add an expectation to the stateless-filter case asserting `StreamsUncaughtExceptionHandler` is imported from `org.apache.kafka.streams.errors`, not referenced as a nested class.

Reference files themselves already have the correct import. No changes there.

## Working hypothesis

Issue 1 (compile error) is a downstream symptom of Issue 2 (path mismatch). Fix the paths, the model reads the reference, copies the correct import. The new eval expectation pins this so we'd catch a regression.

## Test plan

- [x] Verify no bare `.md` filenames remain: `grep -nE '(^|[^/])[a-z-]+\.md' SKILL.md | grep -v 'references/'` → empty
- [x] Install skill from this branch, re-run Leo's prompt: *"Build me a simple Kafka Streams filter that drops invalid events from a topic. I'm running Apache Kafka locally with docker-compose."*
- [x] Confirm no "File does not exist" errors during reference reads
- [x] Confirm `./gradlew compileJava` succeeds on the generated project with zero manual edits
- [x] Existing eval suite + new expectation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DTX-985]: https://confluentinc.atlassian.net/browse/DTX-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ