### PR TITLE
fix[kafka streams skill]: update approach to deserialization

### DIFF
--- a/skills/kafka-streams-programming/references/cli-commands.md
+++ b/skills/kafka-streams-programming/references/cli-commands.md
@@ -80,9 +80,11 @@ Omit `--value-format` and SR flags for plain text.
 
 | Format | Command |
 |--------|---------|
-| Avro | `kafka-avro-console-consumer --bootstrap-server localhost:9092 --topic <topic> --from-beginning --property schema.registry.url=http://localhost:8081` |
+| Avro | `kafka-avro-console-consumer --bootstrap-server localhost:9092 --topic <topic> --from-beginning --property schema.registry.url=http://localhost:8081 --property print.key=true --key-deserializer org.apache.kafka.common.serialization.StringDeserializer` |
 | Protobuf | `kafka-protobuf-console-consumer` (same args) |
 | JSON Schema | `kafka-json-schema-console-consumer` (same args) |
+
+> The `--key-deserializer` override is required because these schema-aware consumers default `KafkaAvroDeserializer` (or equivalent) for the key, but our topologies write string keys with `Serdes.String()` — a raw UTF-8 key has no `0x00` magic byte + 4-byte schema ID, so the schema deserializer fails on the first record.
 
 ## Producing Test Data
 

--- a/skills/kafka-streams-programming/references/docker-compose.md
+++ b/skills/kafka-streams-programming/references/docker-compose.md
@@ -94,7 +94,9 @@ docker exec schema-registry kafka-avro-console-consumer \
   --topic output-topic \
   --from-beginning \
   --bootstrap-server broker:29092 \
-  --property schema.registry.url=http://localhost:8081
+  --property schema.registry.url=http://localhost:8081 \
+  --property print.key=true \
+  --key-deserializer org.apache.kafka.common.serialization.StringDeserializer
 
 # Stop
 docker compose down
@@ -107,6 +109,7 @@ docker compose down
 - For EOS testing, `transaction.state.log.replication.factor` must be 1 in single-broker mode
 - Schema Registry is required because all data is schematized (project invariant). Never use plain `kafka-console-producer` / `kafka-console-consumer` for schematized topics — always use the schema-aware variants (`kafka-avro-console-producer`, etc.)
 - The `kafka-avro-console-producer` and `kafka-avro-console-consumer` CLIs are bundled in the `schema-registry` container, so run them via `docker exec schema-registry`. Broker-only commands like `kafka-topics` run via `docker exec broker`.
+- `kafka-avro-console-consumer` defaults `KafkaAvroDeserializer` for **both** key and value. Our topologies write string keys with `Serdes.String()` (no SR framing), so always pass `--key-deserializer org.apache.kafka.common.serialization.StringDeserializer` — otherwise the Avro deserializer chokes on the first byte (expects `0x00` magic + 4-byte schema ID). Same applies to `kafka-protobuf-console-consumer` and `kafka-json-schema-console-consumer`.
 - `group.protocol=streams` requires broker version AK 4.2+. The `confluentinc/confluent-local:8.2.0` image bundles CP 8.2 which includes AK 4.2, so it works locally. If using an older image version (e.g., 7.x), comment out `group.protocol=streams` in your Streams config.
 - For local dev, topics can use the `--if-not-exists` flag since `auto.create.topics.enable=true` by default on the local broker, but pre-creating topics with explicit partition counts is still recommended to avoid surprises.
 

--- a/skills/kafka-streams-programming/references/verification.md
+++ b/skills/kafka-streams-programming/references/verification.md
@@ -81,9 +81,14 @@ If the user wants sample data, generate a `SampleDataProducer.java` class and a 
 
 ```bash
 # Avro
+# Keys are Serdes.String() in our topologies — override the default key
+# deserializer so the consumer doesn't try to Avro-decode a raw UTF-8 key
+# (which has no 0x00 magic byte + 4-byte schema ID).
 kafka-avro-console-consumer --bootstrap-server broker:29092 \
   --topic output-topic --from-beginning \
-  --property schema.registry.url=http://localhost:8081
+  --property schema.registry.url=http://localhost:8081 \
+  --property print.key=true \
+  --key-deserializer org.apache.kafka.common.serialization.StringDeserializer
 ```
 
 ### Confluent Cloud


### PR DESCRIPTION
## Description

For context, I ran into this while reviewing the skill recently, Claude's explanation of the error I ran into: 

```
 kafka-avro-console-consumer defaults 
  to KafkaAvroDeserializer for both key
   and value. Our topology writes      
  string keys with Serdes.String() (no
  SR framing), so the Avro deserializer
   chokes on the first byte — it     
  expects a 0x00 magic byte followed by
   a 4-byte schema ID, and a raw UTF-8
  region name doesn't have that.

```

This should fix it so the generated deserializer won't choke. 

