### PR TITLE
chore: fix skill validator in build to reference 'main' default branch

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -37,7 +37,7 @@ global_job_config:
 blocks:
   - name: "Validate Skills"
     run:
-      when: "change_in('/skills/')"
+      when: "change_in('/skills/', {default_branch: 'main'})"
     task:
       jobs:
         - name: "Skill Validator"


### PR DESCRIPTION
## Description

Fix build error:

```
Unknown branch referenced in [change_in](https://docs.ci.confluent.io/reference/conditions-reference#change-in) expression.
Location: blocks[0] / run / when
Error: Unknown git reference 'master'.
```