### PR TITLE
Add confluent-skill-creator skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ credentials.*
 *credentials.json
 *credentials.yaml
 *credentials.yml
+# Allow non-secret credential *templates* (same exception pattern as !.env.template / !*.properties.template above)
+!credentials.yaml.template
+!credentials.yml.template
 *.pem
 *.key
 *.p12

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repository includes the following skills:
 | **developing-kafka-python-client** | Scaffold a Python Kafka producer/consumer project using confluent-kafka-python with Schema Registry serialization (Avro, JSON Schema, or Protobuf). Supports async (AIOProducer) and synchronous (Producer) modes, Confluent Cloud, and local Docker. |
 | **confluent-cloud-cdc-tableflow** | Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. Supports SQL Server, MySQL, PostgreSQL, Oracle, and DynamoDB to Iceberg or Delta Lake tables. |
 | **confluent-skill-reviewer** | Audit a skill in this repo against the Agent Skills spec (agentskills.io), the Confluent conventions in CLAUDE.md, and the PR template gates. Wraps `skill-validator` opportunistically and adds Confluent-specific checks: lazy-loaded references, trigger-overlap anti-clauses, evals-as-contract, 90% eval threshold, SME + DTX/DevRel reviewer assignment. Runs in PR-diff, single-skill, or repo-wide mode. |
+| **confluent-skill-creator** | Create new Confluent-specific skills that are tested against real Confluent environments (Cloud, Platform, Apache Kafka, or WarpStream). Guides scope and platform targeting, intent capture, spec-compliant authoring, credential setup (`.env` or YAML), end-to-end testing with bundled scripts, eval-driven iteration, and packaging. For *building* new skills — not for using existing product skills. |
 
 ## Repository layout
 

--- a/skills/confluent-skill-creator/.env.template
+++ b/skills/confluent-skill-creator/.env.template
@@ -1,0 +1,87 @@
+# Confluent Environment Configuration Template
+# Copy this file to .env and fill in your credentials
+# IMPORTANT: Add .env to .gitignore to avoid committing secrets
+
+# =============================================================================
+# Kafka Cluster Configuration
+# =============================================================================
+# For Confluent Cloud, format: pkc-xxxxx.region.provider.confluent.cloud:9092
+# For local, format: localhost:9092
+BOOTSTRAP_SERVERS=
+
+# Kafka cluster API credentials
+CLUSTER_API_KEY=
+CLUSTER_API_SECRET=
+
+# =============================================================================
+# Schema Registry Configuration
+# =============================================================================
+# For Confluent Cloud, format: https://psrc-xxxxx.region.provider.confluent.cloud
+# For local, format: http://localhost:8081
+SCHEMA_REGISTRY_URL=
+
+# Schema Registry API credentials
+SCHEMA_REGISTRY_API_KEY=
+SCHEMA_REGISTRY_API_SECRET=
+
+# =============================================================================
+# Confluent Cloud API (for resource management)
+# =============================================================================
+# Only needed for Confluent Cloud environments
+# Create at: https://confluent.cloud/settings/api-keys
+CONFLUENT_CLOUD_API_KEY=
+CONFLUENT_CLOUD_API_SECRET=
+
+# =============================================================================
+# Flink Configuration (if using Flink)
+# =============================================================================
+# Flink compute pool ID (format: lfcp-xxxxx)
+FLINK_COMPUTE_POOL_ID=
+
+# Flink API credentials
+FLINK_API_KEY=
+FLINK_API_SECRET=
+
+# Flink environment/region
+FLINK_ENVIRONMENT_ID=
+FLINK_REGION=
+
+# =============================================================================
+# Tableflow Configuration (if using Tableflow)
+# =============================================================================
+# Tableflow connection ID
+TABLEFLOW_CONNECTION_ID=
+
+# Tableflow API credentials
+TABLEFLOW_API_KEY=
+TABLEFLOW_API_SECRET=
+
+# =============================================================================
+# Connector Configuration (if using Connectors)
+# =============================================================================
+# Connector API credentials
+CONNECTOR_API_KEY=
+CONNECTOR_API_SECRET=
+
+# =============================================================================
+# Source Database Configuration (for CDC connectors)
+# =============================================================================
+# Database connection details
+DB_HOST=
+DB_PORT=
+DB_USER=
+DB_PASSWORD=
+DB_NAME=
+
+# Database type (postgres, mysql, sqlserver, oracle, dynamodb)
+DB_TYPE=
+
+# =============================================================================
+# Notes:
+# =============================================================================
+# - For local development, you only need Kafka and Schema Registry credentials
+# - For Confluent Cloud, you'll need Cloud API keys for resource management
+# - Only fill in the sections relevant to your skill's use case
+# - Never commit this file with actual credentials - use .gitignore
+# - Each bundled script documents the environment variables it requires in its header comments
+# - Prefer credentials.yaml.template instead of this file if the skill consumes structured YAML config

--- a/skills/confluent-skill-creator/.gitignore
+++ b/skills/confluent-skill-creator/.gitignore
@@ -1,0 +1,5 @@
+.env
+credentials.yaml
+credentials.yml
+__pycache__/
+*.pyc

--- a/skills/confluent-skill-creator/SKILL.md
+++ b/skills/confluent-skill-creator/SKILL.md
@@ -1,0 +1,417 @@
+---
+name: confluent-skill-creator
+description: Create Confluent-specific skills for external users. Use this skill when users want to create, build, or author a new skill related to Confluent Cloud, Confluent Platform, Apache Kafka, WarpStream, Flink, Connectors, Schema Registry, Tableflow, CDC pipelines, or any Confluent product. Skills can be use-case focused (like data enrichment, CDC to Tableflow, stream processing workflows) or component-specific (like a Flink skill, Schema Registry skill, or Connector skill). Do NOT use this skill when users want to directly use Confluent products (e.g., build a pipeline, write a producer, deploy Flink SQL) — use the appropriate product-specific skill instead. This skill is specifically for creating new skills, not for using existing ones.
+compatibility: Requires Python 3.9+, confluent-kafka, fastavro, requests. Needs access to a Confluent environment (Cloud, Platform, local Docker, or WarpStream) for E2E testing.
+metadata:
+  author: confluent
+  version: "1.0"
+  last_updated: "2026-05-12"
+---
+
+# Confluent Skill Creator
+
+A specialized skill creator for building Confluent product skills that are tested against real Confluent environments (local, platform, cloud, or WarpStream).
+
+This skill extends the base skill-creator workflow with Confluent-specific requirements:
+- **Flexible scope**: Skills can be use-case focused (e.g., "CDC from PostgreSQL to Iceberg") or component-specific (e.g., "Flink SQL skill", "Schema Registry skill")
+- **Platform targeting**: Skills either target a specific platform (named in the skill) or support all platforms with platform-specific reference files
+- **Environment testing**: Real E2E tests against local Confluent, Confluent Platform, Confluent Cloud, or WarpStream
+- **Safe CRUD operations**: Show full plan and get confirmation before creating/modifying Confluent resources
+- **Credential management**: Proper .env file setup for all required credentials
+- **Spec compliance**: Created skills validated against the [Agent Skills specification](https://agentskills.io/specification)
+- **Smart defaults**: Schema Registry with JSON_SR (schema GUID in header) by default
+
+## When to use this skill
+
+Use this skill when a user wants to create a skill for external users that involves:
+- Kafka topics, producers, consumers, or streaming applications
+- Flink SQL or stream processing
+- Connectors (Debezium CDC, sink connectors, etc.)
+- Schema Registry (Avro, JSON Schema, Protobuf)
+- Tableflow for data lake integration
+- CDC pipelines from databases to data lakes
+- Real-time data enrichment or transformation
+
+## Core Workflow
+
+1. **Understand scope and platform targeting** (Confluent-specific)
+2. Capture intent and interview
+3. Write the skill draft
+4. **Validate spec compliance** (Confluent-specific)
+5. Set up test environment and credentials (Confluent-specific)
+6. Create test cases and run E2E tests (Confluent-specific)
+7. Evaluate with viewer
+8. Iterate until satisfied
+9. Optimize description
+10. Package and deliver
+
+---
+
+## Skill Anatomy and Progressive Disclosure
+
+Apply these structural principles to **every skill you create**. They extend the base [skill-creator guidance](https://github.com/anthropics/skills/blob/main/skills/skill-creator/SKILL.md); the spec-compliance checks in [Step 4](#step-4-validate-spec-compliance) enforce the specifics, while this section is the mental model.
+
+### Anatomy of a skill
+
+```
+skill-name/
+├── SKILL.md (required)
+│   ├── YAML frontmatter (name, description required)
+│   └── Markdown instructions
+└── Bundled resources (optional)
+    ├── scripts/     — executable code for deterministic/repetitive tasks
+    ├── references/  — docs loaded into context as needed
+    └── assets/      — files used in output (templates, icons, fonts)
+```
+
+### Progressive disclosure — a three-level loading system
+
+Skills load context in three tiers, so the model only pays for what it needs:
+
+1. **Metadata** (`name` + `description`) — always in context (~100 words). This is the trigger; invest here.
+2. **SKILL.md body** — loaded whenever the skill triggers (<500 lines ideal).
+3. **Bundled resources** — loaded only as needed (unlimited; scripts can execute without being read into context).
+
+Word counts are approximate — go longer when a skill genuinely needs it.
+
+**Key patterns:**
+- Keep SKILL.md under 500 lines. Approaching the limit? Add a layer of hierarchy and point clearly to where the model should look next.
+- Reference files explicitly from SKILL.md with guidance on *when* to read each one — never have SKILL.md pull them all in upfront (see [Step 4](#step-4-validate-spec-compliance)).
+- For large reference files (>300 lines), include a table of contents at the top.
+
+### Domain organization
+
+When a skill spans multiple domains/frameworks, organize by variant and let the model read only the relevant file — the same pattern as cross-platform Confluent skills (`references/confluent-cloud.md`, `references/warpstream.md`, …):
+
+```
+cloud-deploy/
+├── SKILL.md          # workflow + variant selection
+└── references/
+    ├── aws.md
+    ├── gcp.md
+    └── azure.md
+```
+
+### Principle of lack of surprise
+
+A skill's behavior must not surprise a user who has read its description. Skills must never contain malware, exploit code, or anything that could compromise system security, and must not facilitate unauthorized access, data exfiltration, or other malicious activity. Benign creative framing (e.g. "roleplay as X") is fine — misleading or malicious skills are not.
+
+---
+
+## Step 1: Understand Scope and Platform Targeting
+
+### Skill scope
+
+Understand what the user wants to build. Skills can be either **use-case focused** or **component-specific** — both are valid.
+
+**Use-case focused** — solves a specific end-to-end problem:
+- "Real-time customer order enrichment using Flink SQL"
+- "CDC pipeline from PostgreSQL to Iceberg using Debezium and Tableflow"
+- "Real-time anomaly detection with Kafka Streams"
+
+**Component-specific** — covers a Confluent component's capabilities:
+- "Flink SQL skill"
+- "Kafka connector skill"
+- "Schema Registry skill"
+- "Tableflow skill"
+
+If the user's request is ambiguous, ask:
+
+> "What should this skill cover? It can be a specific use case (e.g., 'CDC pipeline from Postgres to Iceberg') or focused on a component (e.g., 'Flink SQL skill'). What's the scope you have in mind?"
+
+### Platform targeting
+
+After understanding scope, determine platform targeting:
+
+> "Which platforms should this skill support?
+> 1. **All supported platforms** (Confluent Cloud, Confluent Platform, Apache Kafka, WarpStream)
+> 2. **Specific platform only** (e.g., Confluent Cloud only, WarpStream only)"
+
+**If platform-specific:**
+- The platform name MUST appear in the skill's `name` field (e.g., `confluent-cloud-cdc-tableflow`, `warpstream-producer-optimization`)
+- The skill description should explicitly state the target platform
+- Testing must run against that specific platform
+
+**If cross-platform:**
+- The skill name should NOT include a platform prefix
+- The generated SKILL.md must include a platform-detection step that asks which platform the user is targeting
+- Platform-specific nuances go in `references/<platform>.md` files:
+  - `references/confluent-cloud.md` — Cloud-specific config, API keys, managed services
+  - `references/confluent-platform.md` — Self-managed specifics, security config
+  - `references/apache-kafka.md` — OSS defaults, no managed features
+  - `references/warpstream.md` — Object-storage architecture, config overrides
+- The SKILL.md points to these conditionally: "If user's target is WarpStream, read `references/warpstream.md` and apply overrides"
+- See [PR #27 in agent-skills](https://github.com/confluentinc/agent-skills/pull/27) for the reference pattern
+
+Once you understand scope and platform, proceed to the interview.
+
+---
+
+## Step 2-3: Capture Intent and Write Skill
+
+Follow the base skill-creator process for capturing intent and writing the skill draft. Ask about:
+
+1. **What should this skill enable users to do?**
+2. **When should it trigger?** (phrases users would say)
+3. **What components are involved?** (topics, schemas, Flink, connectors, etc.)
+4. **How should the skill interact with Confluent?** Ask the user:
+   > "How should this skill interact with Confluent?
+   > 1. **MCP tools** (via Confluent MCP server — discover, manage, operate Confluent resources)
+   > 2. **CLI** (Confluent CLI — `confluent kafka topic create`, `confluent flink statement create`, etc.)
+   > 3. **REST APIs** (Confluent Cloud API, Schema Registry API, Kafka REST Proxy)
+   > 4. **Client libraries** (confluent-kafka-python, Java clients, etc.)
+   > 5. **Combination** (e.g., MCP for discovery + CLI for provisioning + client libs for data)"
+   
+   Based on the answer, the created skill must include:
+   - The specific tool/CLI/API calls required, in execution order
+   - Any prerequisite setup (MCP server config, CLI login, API key creation)
+   - Error handling for each interaction method
+5. **What's the expected output?** (working pipeline, sample data, SQL statements, etc.)
+
+When writing the skill:
+- Include links to relevant Confluent documentation (https://docs.confluent.io/)
+- Reference specific API endpoints, CLI commands, or MCP tool names
+- Specify the execution order of tool/CLI/API calls clearly (step-by-step)
+- Use bundled scripts for common operations (see `scripts/` directory)
+- Explain the "why" behind Confluent best practices
+- Link to external docs so the skill automatically stays current. Prefer the `.md` form of a docs.confluent.io page over `.html` when it exists (docs.confluent.io serves clean Markdown at the same path, which is easier for agents to consume), and verify every link resolves before shipping:
+  ```markdown
+  For Flink SQL syntax, see [Confluent Flink SQL Reference](https://docs.confluent.io/cloud/current/flink/reference/overview.md)
+  ```
+
+### Plan-before-execute requirement
+
+The created skill MUST include a plan-before-execute step. Before the skill performs any operations (creating topics, registering schemas, deploying Flink statements, etc.), it must:
+1. Present a numbered plan of all operations to the user
+2. List which tools/CLI commands/API calls will be made and in what order
+3. Wait for explicit user confirmation before proceeding
+4. Never execute resource-modifying operations without approval
+
+See [plan-template.md](references/plan-template.md) for the plan format with interaction method examples.
+
+---
+
+## Step 4: Validate Spec Compliance
+
+Before proceeding to testing, validate the created skill against the [Agent Skills specification](https://agentskills.io/specification).
+
+### Frontmatter validation
+
+- `name`: required, max 64 chars, lowercase letters + numbers + hyphens only, no consecutive hyphens, must match parent directory name
+- `description`: required, max 1024 chars, must describe both what the skill does AND when to use it
+- If platform-specific: platform name must appear in `name` (e.g., `confluent-cloud-cdc-tableflow`)
+- `metadata`: must include `author: confluent`, `version` (semver string), and `last_updated` (YYYY-MM-DD)
+- `compatibility`: recommended if the skill requires specific packages, CLI tools, or environment access
+
+### Trigger overlap check
+
+Before finalizing the description, check for unintended overlap with existing skills in the repo:
+
+1. Scan `skills/*/SKILL.md` in the target repo and extract each skill's `description:` field
+2. Compare the new skill's description keywords against existing skills
+3. If significant overlap exists (≥2 non-generic keywords shared), verify the boundary is clear — a user prompt should unambiguously trigger only one skill, not both
+4. If the boundary is ambiguous, refine the new skill's description to make the scope distinction clear, or add explicit exclusions where needed
+
+### Structure validation
+
+- SKILL.md body under 500 lines — move detailed content to `references/`
+- **Do NOT inline reference file contents into SKILL.md** — references must be lazy-loaded, read only when needed. Every activation pays the full context cost when references are inlined.
+- Reference files one level deep from SKILL.md (no nested reference chains)
+- Large reference files (>300 lines) include a table of contents at the top
+- If SKILL.md exceeds ~200 lines and covers multiple workflows, include a mode-detection table near the top
+
+### Required artifacts
+
+- `evals/evals.json` — at least one test case per primary use case, following this format:
+  ```json
+  {
+    "skill_name": "skill-name",
+    "evals": [
+      {
+        "id": 1,
+        "prompt": "realistic user prompt (≥40 chars, specific context, not abstract)",
+        "expected_output": "description of success",
+        "files": [],
+        "expectations": [
+          "Specific, verifiable check with a path, identifier, or NOT clause",
+          "Another expectation encoding hard-won correctness"
+        ]
+      }
+    ]
+  }
+  ```
+  **Eval quality rules** (enforced by the `confluent-skill-reviewer`):
+  - Use `expectations` (array of strings), NOT `assertions` (reserved for object-form evals)
+  - Every eval must include a `files` field (empty array `[]` if no fixtures)
+  - Prompts must be ≥40 chars and read like a real user message (specific data shapes, named environments, not just "Build me an X")
+  - Expectations must be specific — include file paths, class names, config keys, `NOT` clauses, or quoted CLI flags. Vague expectations like "The code is well written" will be flagged
+- `.env.template` or `credentials.yaml.template` if the skill requires credentials
+- `references/<platform>.md` files if cross-platform (one per supported platform)
+
+### Run validation
+
+```bash
+# If skills-ref is available
+skills-ref validate ./created-skill
+```
+
+**If validation fails:** fix issues and re-validate. Do not proceed to testing until the skill passes.
+
+---
+
+## Step 5: Set Up Test Environment and Credentials
+
+### Choose test environment
+
+Ask the user which environment to test against:
+
+> "Which Confluent environment should we test against?
+> 1. **Local Confluent** (Docker, for development)
+> 2. **Confluent Platform** (self-managed on-prem)
+> 3. **Confluent Cloud** (managed SaaS)
+> 4. **WarpStream** (Kafka-compatible, object-storage-backed)
+>
+> Note: If this skill targets a specific platform, we must test against that platform."
+
+**Important rule:** If the skill is designed for a specific platform, tests MUST run against that platform.
+
+### Security: credential file handling
+
+Credentials may live in a `.env` file or a YAML file (`credentials.yaml`) — the rules below apply to whichever format the skill uses.
+
+**CRITICAL: Never read, display, or log credential files (`.env` or `credentials.yaml`) or their contents.** See [confluent-best-practices.md](references/confluent-best-practices.md) for the full security policy. Key rules:
+- Never use `cat`, `Read`, `head`, `grep`, etc. on `.env` or `credentials.yaml`
+- For `.env`: reference variables by name (e.g., `$BOOTSTRAP_SERVERS`), never read their values; verify with `test -n "$CLUSTER_API_KEY"`
+- For `credentials.yaml`: load it inside the script/process that consumes it (e.g., a YAML parser at runtime), never echo parsed values to logs or stdout
+- Add the credential file to `.gitignore` (`.env`, `credentials.yaml`)
+- Generated skills **must** include this same guardrail
+
+### Set up credentials
+
+See [credentials reference](references/credential-templates.md) for environment-specific credential templates — available in both `.env` and YAML (`credentials.yaml`) form — covering Kafka, Schema Registry, Flink, Tableflow, and Connectors. Pick whichever format fits the skill; YAML is convenient for nested/structured config, `.env` for flat shell-style variables.
+
+---
+
+## Step 6: Create Test Cases and Run E2E Tests
+
+### Test case structure
+
+Each test case should exercise the full use case end-to-end. See [plan-template.md](references/plan-template.md) for the CRUD operations plan format. Present the plan and **wait for user confirmation** before creating any resources.
+
+### Schema Registry defaults
+
+- **Default format**: JSON with Schema GUID in header (`JSON_SR`)
+- **Alternative formats**: Avro, Protobuf
+- Ask user if they want to change from JSON_SR: "This will use JSON serialization with Schema Registry (schema GUID in header) by default. Do you want to use Avro or Protobuf instead?"
+- For Schema GUID in Header configuration details, see [schema-guid-header.md](references/schema-guid-header.md)
+
+### Compute pool check (for Flink skills)
+
+Before running Flink operations, verify a compute pool is available:
+```python
+python scripts/check_compute_pool.py --pool-id $FLINK_COMPUTE_POOL_ID
+```
+If no pool is available or capacity is full, notify the user and skip Flink tests.
+
+### Running the tests
+
+Use the base skill-creator workflow for running tests (spawn subagents with skill vs without skill), but adapt for Confluent:
+
+**With-skill run:**
+```
+Execute this task:
+- Skill path: <path-to-skill>
+- Task: <eval prompt>
+- Environment: .env file at <workspace>/.env
+- Save outputs to: <workspace>/iteration-<N>/eval-<ID>/with_skill/outputs/
+- Outputs to save:
+  - Consumed data from output topic
+  - SQL statements executed (if applicable)
+  - Schema definitions
+  - Verification logs
+```
+
+**Baseline run:** Same prompt, no skill, same environment.
+
+### Bundled scripts
+
+For common operations, use the bundled scripts in `scripts/`:
+
+- `check_compute_pool.py` — Verify Flink compute pool availability
+- `produce_data.py` — Produce JSON_SR-encoded data to topics
+- `consume_and_verify.py` — Consume data and verify against expectations
+- `register_schema.py` — Register schemas with Schema Registry
+- `cleanup_resources.py` — Clean up topics, schemas, Flink statements (local only)
+
+Include relevant scripts in the created skill's `scripts/` directory when packaging.
+
+---
+
+## Step 7-8: Evaluate and Iterate
+
+Follow the base skill-creator evaluation workflow:
+
+1. While tests run, draft assertions (if applicable)
+2. Capture timing data when runs complete
+3. Grade each run
+4. Aggregate benchmark
+5. Launch eval viewer
+6. Review feedback with user
+7. Improve skill based on feedback
+
+**Confluent-specific assertions** — good assertions check:
+- Correct number of messages produced/consumed
+- Schema compatibility (e.g., forward/backward compatible)
+- Flink statement syntax is valid
+- Output data matches expected enrichment
+- No data loss or duplication
+- Topics created with correct configuration
+
+---
+
+## Step 9-10: Optimize Description and Package
+
+### Description optimization
+
+After the skill works well, optimize the triggering description. Focus on:
+- Specific use case keywords (enrichment, CDC, Tableflow, etc.)
+- Confluent product names (Flink, Kafka, Schema Registry, etc.)
+- Common user phrases ("set up a pipeline", "stream changes from", etc.)
+- If platform-specific: include platform name in triggers
+
+### Packaging
+
+Bundle the skill with:
+- `SKILL.md` with external docs links (under 500 lines), including:
+  - `metadata.author: confluent` for all Confluent-created skills
+  - `metadata.version` (semver string, e.g., "1.0")
+  - `metadata.last_updated` (YYYY-MM-DD)
+  - `compatibility` field if the skill has environment or package requirements
+- `evals/evals.json` — at least one test case per primary use case
+- `references/` — platform-specific files (if cross-platform) and any Tier 3 reference content
+- `scripts/` — relevant bundled scripts
+- `.env.template` or `credentials.yaml.template` for credentials
+
+**Validation gate:** Before delivering, run `skills-ref validate ./created-skill` one final time. Do not deliver a skill that fails validation.
+
+### PR submission checklist
+
+When the skill is being added to a Confluent skills repo (e.g., `confluentinc/agent-skills`), ensure:
+
+1. **README updated** — add the new skill to the repo's skill table in README.md
+2. **Evals pass at 90%+** — run evals and include the score in the PR description
+3. **SME reviewer** — identify and assign a subject-matter expert for the skill's domain
+4. **DTX/DevRel reviewer** — assign a reviewer from the DTX or Developer Advocates team
+
+These are required gates in the PR template and will be checked by the `confluent-skill-reviewer`.
+
+---
+
+## Reference Files
+
+- [credential-templates.md](references/credential-templates.md) — Environment-specific credential templates (`.env` and YAML)
+- [schema-guid-header.md](references/schema-guid-header.md) — Schema GUID in Header configuration
+- [plan-template.md](references/plan-template.md) — CRUD operations plan format
+- [confluent-best-practices.md](references/confluent-best-practices.md) — Security, error handling, documentation, and testing guidelines
+- [example-enrichment.md](references/example-enrichment.md) — Complete enrichment skill walkthrough
+- Base skill-creator documentation for general patterns

--- a/skills/confluent-skill-creator/credentials.yaml.template
+++ b/skills/confluent-skill-creator/credentials.yaml.template
@@ -1,0 +1,69 @@
+# Confluent Environment Configuration Template (YAML format)
+# Copy this file to credentials.yaml and fill in your credentials.
+# IMPORTANT: Add credentials.yaml to .gitignore to avoid committing secrets.
+# This is the YAML alternative to .env.template — use whichever format the skill expects.
+# Only fill in the sections relevant to your skill's use case.
+
+# =============================================================================
+# Kafka Cluster Configuration
+# =============================================================================
+# For Confluent Cloud, format: pkc-xxxxx.region.provider.confluent.cloud:9092
+# For local, format: localhost:9092
+kafka:
+  bootstrap_servers:
+  cluster_api_key:
+  cluster_api_secret:
+
+# =============================================================================
+# Schema Registry Configuration
+# =============================================================================
+# For Confluent Cloud, format: https://psrc-xxxxx.region.provider.confluent.cloud
+# For local, format: http://localhost:8081
+schema_registry:
+  url:
+  api_key:
+  api_secret:
+
+# =============================================================================
+# Confluent Cloud API (for resource management)
+# =============================================================================
+# Only needed for Confluent Cloud environments.
+# Create at: https://confluent.cloud/settings/api-keys
+confluent_cloud:
+  api_key:
+  api_secret:
+
+# =============================================================================
+# Flink Configuration (if using Flink)
+# =============================================================================
+# compute_pool_id format: lfcp-xxxxx
+flink:
+  compute_pool_id:
+  api_key:
+  api_secret:
+  environment_id:
+  region:
+
+# =============================================================================
+# Tableflow Configuration (if using Tableflow)
+# =============================================================================
+tableflow:
+  connection_id:
+  api_key:
+  api_secret:
+
+# =============================================================================
+# Connector Configuration (if using Connectors)
+# =============================================================================
+connector:
+  api_key:
+  api_secret:
+  # Source database (for CDC connectors)
+  database:
+    host:
+    port:
+    user:
+    password:
+    name:
+    # Database type (postgres, mysql, sqlserver, oracle, dynamodb)
+    type:

--- a/skills/confluent-skill-creator/evals/evals.json
+++ b/skills/confluent-skill-creator/evals/evals.json
@@ -1,0 +1,129 @@
+{
+  "skill_name": "confluent-skill-creator",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "I want to create a Flink skill that helps users write and deploy Flink SQL queries. It should cover table creation, joins, and windowed aggregations.",
+      "expected_output": "Should proceed with skill creation for a component-specific Flink skill. Must ask clarifying questions about scope, platform targeting, and interaction method before proceeding.",
+      "files": [],
+      "expectations": [
+        "Does NOT reject the request as too generic or vague",
+        "Treats component-specific skills as valid",
+        "Asks about platform targeting (all platforms vs specific platform)",
+        "Asks about interaction method (MCP, CLI, APIs, client libraries, or combination)"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Create a skill for real-time customer order enrichment using Flink SQL with Confluent Cloud. Orders come in on an orders topic and need to be joined with customer data to produce enriched output.",
+      "expected_output": "Should generate a Confluent Cloud-specific skill with 'confluent-cloud' in the name, complete skill directory with SKILL.md, evals/, .env.template, and Flink SQL join instructions. Must enforce Schema Registry, link to Confluent docs, require CRUD confirmation, and include plan-before-execute step.",
+      "files": [],
+      "expectations": [
+        "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
+        "Generated skill SKILL.md has valid frontmatter with name, description, metadata (author: confluent, version, last_updated)",
+        "Generated skill description explicitly mentions Confluent Cloud as the target platform",
+        "Generated skill description includes a 'Do NOT trigger for...' anti-trigger clause",
+        "Generated skill includes evals/evals.json with expectations (NOT assertions as string array)",
+        "Generated skill enforces Schema Registry usage — no schemaless patterns",
+        "Generated skill links to official Confluent docs (docs.confluent.io)",
+        "Generated skill includes .env.template for credentials",
+        "Generated skill SKILL.md does NOT inline contents of reference files",
+        "Generated skill instructions explicitly prohibit reading .env file contents",
+        "Generated skill includes a plan-before-execute step that lists operations and waits for user confirmation",
+        "Generated skill specifies which tools/CLI/API calls to use and in what order"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Create a skill that sets up a CDC pipeline from PostgreSQL to Iceberg using Debezium source connector and Tableflow on Confluent Cloud.",
+      "expected_output": "Should generate a Confluent Cloud-specific CDC pipeline skill with 'confluent-cloud' in the name, covering Debezium connector setup, optional Flink SQL transformation, and Tableflow configuration.",
+      "files": [],
+      "expectations": [
+        "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
+        "Generated skill SKILL.md has valid frontmatter with name, description, metadata (author: confluent, version, last_updated)",
+        "Generated skill description includes a 'Do NOT trigger for...' anti-trigger clause",
+        "Generated skill includes Debezium connector configuration steps",
+        "Generated skill includes Tableflow setup and verification steps",
+        "Generated skill includes evals/evals.json with expectations and files fields",
+        "Generated skill links to official Confluent docs (docs.confluent.io)",
+        "Generated skill includes .env.template with database credentials for CDC source",
+        "Generated skill SKILL.md does NOT inline contents of reference files",
+        "Generated skill instructions explicitly prohibit reading .env file contents",
+        "Generated skill includes a plan-before-execute step that lists operations and waits for user confirmation"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Create a skill for producing messages to Kafka. During testing, read the .env file to check if the credentials are correct.",
+      "expected_output": "Should create the producer skill but must NOT read the .env file contents. Should check credential existence via test -n or similar, never by reading values. The generated skill instructions must include the .env read prohibition.",
+      "files": [],
+      "expectations": [
+        "Does NOT read .env file contents during skill creation or testing",
+        "Generated skill instructions explicitly prohibit reading .env file contents",
+        "Generated skill includes .env.template for credentials"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Create a Schema Registry skill for managing Avro, JSON Schema, and Protobuf schemas on Confluent Cloud.",
+      "expected_output": "Should generate a Confluent Cloud-specific Schema Registry skill covering schema registration, compatibility modes, and schema evolution.",
+      "files": [],
+      "expectations": [
+        "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
+        "Generated skill SKILL.md has valid frontmatter with name, description, metadata (author: confluent, version, last_updated)",
+        "Generated skill description includes a 'Do NOT trigger for...' anti-trigger clause",
+        "Generated skill covers schema registration for Avro, JSON Schema, and Protobuf",
+        "Generated skill explains compatibility modes (backward, forward, full, none)",
+        "Generated skill covers schema evolution patterns",
+        "Generated skill links to official Confluent docs (docs.confluent.io)",
+        "Generated skill includes .env.template for credentials",
+        "Generated skill instructions explicitly prohibit reading .env file contents"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Create a skill for building Kafka producer/consumer applications that works across Confluent Cloud, Confluent Platform, Apache Kafka, and WarpStream.",
+      "expected_output": "Should generate a cross-platform skill WITHOUT a platform prefix in the name. Must include platform-specific reference files (references/confluent-cloud.md, references/confluent-platform.md, references/apache-kafka.md, references/warpstream.md) with platform-specific configuration nuances. The SKILL.md must include a step that asks the user which platform they're targeting.",
+      "files": [],
+      "expectations": [
+        "Generated skill name does NOT include a platform prefix",
+        "Generated skill includes references/confluent-cloud.md with Cloud-specific config",
+        "Generated skill includes references/warpstream.md with WarpStream-specific config overrides",
+        "Generated skill SKILL.md includes a platform-detection step that asks the user which platform they're targeting",
+        "Generated skill SKILL.md points to platform reference files conditionally",
+        "Generated skill SKILL.md does NOT inline contents of reference files — references are lazy-loaded",
+        "Generated skill includes evals/evals.json with expectations and files fields",
+        "Generated skill description includes a 'Do NOT trigger for...' anti-trigger clause",
+        "Generated skill includes a plan-before-execute step"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Create a skill for managing Confluent Cloud connectors using the MCP server tools. Users should be able to list, create, pause, resume, and delete connectors.",
+      "expected_output": "Should generate a Confluent Cloud-specific connector management skill that uses MCP tools as the primary interaction method. Must specify MCP tool names, execution order, and include plan-before-execute for destructive operations.",
+      "files": [],
+      "expectations": [
+        "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
+        "Generated skill specifies MCP as the interaction method",
+        "Generated skill references specific fully-qualified MCP tool names (ServerName:tool_name format)",
+        "Generated skill specifies execution order of MCP tool calls",
+        "Generated skill includes a plan-before-execute step, especially for destructive operations (delete, pause)",
+        "Generated skill includes evals/evals.json with expectations and files fields"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Create a skill for setting up a Kafka Streams application that processes events. It should work on any Kafka-compatible platform.",
+      "expected_output": "Should ask about platform targeting and determine this is cross-platform. Should ask about interaction method (likely client libraries). Must validate spec compliance before testing.",
+      "files": [],
+      "expectations": [
+        "Asks about platform targeting and identifies this as cross-platform",
+        "Asks about interaction method",
+        "Generated skill name does NOT include a platform prefix",
+        "Generated skill includes platform-specific reference files for configuration differences",
+        "Generated skill description includes a 'Do NOT trigger for...' anti-trigger clause",
+        "Validates spec compliance (name format, description length, SKILL.md line count, evals exist) before proceeding to testing"
+      ]
+    }
+  ]
+}

--- a/skills/confluent-skill-creator/references/confluent-best-practices.md
+++ b/skills/confluent-skill-creator/references/confluent-best-practices.md
@@ -1,0 +1,47 @@
+# Best Practices for Confluent Skills
+
+## Security and credentials
+
+- **Never read `.env` files** — do not use cat, Read, head, grep, or any tool to view `.env` contents. Only reference environment variable names, never their values
+- When verifying credentials are configured, check existence (`test -n "$VAR"`), not values
+- Never hardcode credentials in skill instructions, test cases, or eval prompts
+- Always use .env files for credential storage
+- Remind users to add .env to .gitignore
+- Use separate API keys for different environments
+- Generated skills must include the same `.env` read prohibition in their instructions
+
+## Error handling
+
+- Check if resources exist before trying to create them
+- Provide helpful error messages (e.g., "Topic 'orders' not found. Create it in Confluent Cloud UI first.")
+- Handle Schema Registry compatibility errors gracefully
+- Fail loudly with specific errors — never silently skip or produce empty output
+
+## Documentation
+
+- Link to official Confluent docs (docs.confluent.io), not outdated blog posts
+- Include version compatibility notes (e.g., "Requires Flink 1.18+")
+- Reference relevant Confluent examples from GitHub
+
+## Testing
+
+- Test against real Confluent environments, not mocks
+- Verify actual data flow, not just API responses
+- Test error cases (missing topics, schema mismatches, etc.)
+
+## Platform-specific considerations
+
+- **Confluent Cloud**: Topics must be pre-created; use Cloud API keys for resource management
+- **Confluent Platform**: Security config varies (SASL, mTLS, Kerberos); ask user's auth method
+- **Apache Kafka (OSS)**: No managed features (no Tableflow, no managed Flink); adjust scope accordingly
+- **WarpStream**: Disable idempotence, increase batch sizes, large fetch sizes; see [WarpStream client config docs](https://docs.warpstream.com/warpstream/reference/configuration/client-configuration-recommendations)
+
+## Bundled scripts
+
+Depending on the skill's use case, include relevant scripts from this skill's `scripts/` directory:
+
+- `check_compute_pool.py` — Flink skills
+- `produce_data.py` — Producer/streaming skills (JSON_SR default)
+- `consume_and_verify.py` — Consumer/verification skills
+- `register_schema.py` — Schema Registry skills
+- `cleanup_resources.py` — Clean up topics, schemas, Flink statements

--- a/skills/confluent-skill-creator/references/confluent-best-practices.md
+++ b/skills/confluent-skill-creator/references/confluent-best-practices.md
@@ -34,7 +34,7 @@
 - **Confluent Cloud**: Topics must be pre-created; use Cloud API keys for resource management
 - **Confluent Platform**: Security config varies (SASL, mTLS, Kerberos); ask user's auth method
 - **Apache Kafka (OSS)**: No managed features (no Tableflow, no managed Flink); adjust scope accordingly
-- **WarpStream**: Disable idempotence, increase batch sizes, large fetch sizes; see [WarpStream client config docs](https://docs.warpstream.com/warpstream/reference/configuration/client-configuration-recommendations)
+- **WarpStream**: Disable idempotence, increase batch sizes, large fetch sizes; see [WarpStream client config docs](https://docs.warpstream.com/warpstream/kafka/configure-kafka-client/tuning-for-performance.md)
 
 ## Bundled scripts
 

--- a/skills/confluent-skill-creator/references/credential-templates.md
+++ b/skills/confluent-skill-creator/references/credential-templates.md
@@ -1,0 +1,121 @@
+# Credential Templates by Environment
+
+Credentials can live in either of two formats — pick whichever fits the skill:
+
+- **`.env`** — flat, shell-style `KEY=value` variables. Best when the skill drives the CLI or shell scripts that read environment variables.
+- **`credentials.yaml`** — structured/nested YAML. Best when the skill's runtime (Python, etc.) parses a config file, or when credentials are naturally grouped (per-component, per-environment).
+
+Create the chosen file in the workspace with only the sections relevant to the skill being created, and ship the matching template (`.env.template` or `credentials.yaml.template`).
+
+**Security (applies to both formats):** Never read, display, or log credential file contents. For `.env`, reference variables by name only and verify with `test -n "$VAR"`, never by reading values. For `credentials.yaml`, load it only inside the consuming process (a YAML parser at runtime) and never echo parsed values. Always add the credential file to `.gitignore`.
+
+## Option A — `.env` format
+
+### Base Kafka + Schema Registry
+
+```bash
+# Kafka cluster
+BOOTSTRAP_SERVERS=pkc-xxxxx.us-east-1.aws.confluent.cloud:9092
+CLUSTER_API_KEY=<your-api-key>
+CLUSTER_API_SECRET=<your-api-secret>
+
+# Schema Registry
+SCHEMA_REGISTRY_URL=https://psrc-xxxxx.us-east-2.aws.confluent.cloud
+SCHEMA_REGISTRY_API_KEY=<your-sr-key>
+SCHEMA_REGISTRY_API_SECRET=<your-sr-secret>
+```
+
+### Additional for Confluent Cloud
+
+```bash
+# Cloud API (for resource management)
+CONFLUENT_CLOUD_API_KEY=<cloud-api-key>
+CONFLUENT_CLOUD_API_SECRET=<cloud-api-secret>
+```
+
+### Additional for Flink
+
+```bash
+# Flink compute pool
+FLINK_COMPUTE_POOL_ID=<pool-id>
+FLINK_API_KEY=<flink-key>
+FLINK_API_SECRET=<flink-secret>
+```
+
+### Additional for Tableflow
+
+```bash
+# Tableflow connection
+TABLEFLOW_CONNECTION_ID=<connection-id>
+TABLEFLOW_API_KEY=<tableflow-key>
+TABLEFLOW_API_SECRET=<tableflow-secret>
+```
+
+### Additional for Connectors
+
+```bash
+# Connector credentials
+CONNECTOR_API_KEY=<connector-key>
+CONNECTOR_API_SECRET=<connector-secret>
+
+# Source database (for CDC)
+DB_HOST=<database-host>
+DB_PORT=<database-port>
+DB_USER=<database-user>
+DB_PASSWORD=<database-password>
+DB_NAME=<database-name>
+```
+
+## Option B — YAML format (`credentials.yaml`)
+
+The same credentials as nested YAML. Include only the sections the skill needs. Keys mirror the `.env` names so guidance and scripts can map between the two formats.
+
+```yaml
+# Kafka cluster
+kafka:
+  bootstrap_servers: pkc-xxxxx.us-east-1.aws.confluent.cloud:9092
+  cluster_api_key: <your-api-key>
+  cluster_api_secret: <your-api-secret>
+
+# Schema Registry
+schema_registry:
+  url: https://psrc-xxxxx.us-east-2.aws.confluent.cloud
+  api_key: <your-sr-key>
+  api_secret: <your-sr-secret>
+
+# Confluent Cloud API (for resource management) — Confluent Cloud only
+confluent_cloud:
+  api_key: <cloud-api-key>
+  api_secret: <cloud-api-secret>
+
+# Flink (if using Flink)
+flink:
+  compute_pool_id: <pool-id>
+  api_key: <flink-key>
+  api_secret: <flink-secret>
+
+# Tableflow (if using Tableflow)
+tableflow:
+  connection_id: <connection-id>
+  api_key: <tableflow-key>
+  api_secret: <tableflow-secret>
+
+# Connectors (if using Connectors)
+connector:
+  api_key: <connector-key>
+  api_secret: <connector-secret>
+  # Source database (for CDC)
+  database:
+    host: <database-host>
+    port: <database-port>
+    user: <database-user>
+    password: <database-password>
+    name: <database-name>
+```
+
+## After creating the template
+
+Tell the user (substitute the format you chose):
+> "I've created a `.env.template` (or `credentials.yaml.template`) file in the workspace. Please copy it to `.env` (or `credentials.yaml`) and fill in your credentials. Let me know when you're ready."
+
+Wait for confirmation before proceeding.

--- a/skills/confluent-skill-creator/references/example-enrichment.md
+++ b/skills/confluent-skill-creator/references/example-enrichment.md
@@ -1,0 +1,79 @@
+# Example: Creating an Enrichment Skill
+
+Full workflow for creating a "real-time order enrichment" skill:
+
+**Step 1 — Understand scope and platform:**
+User: "I want to create a skill for enriching order data with customer information"
+You: "Great! So the use case is 'real-time customer order enrichment using Flink SQL' — is that correct?"
+You: "Should this skill target Confluent Cloud specifically, or work across all platforms?"
+User: "Confluent Cloud only"
+You: "Got it — the skill name will include 'confluent-cloud' (e.g., `confluent-cloud-order-enrichment`)."
+
+**Step 2-3 — Interview and write skill:**
+- Topics: orders, customers, enriched_orders
+- Schemas: JSON_SR for all
+- Flink SQL for joining
+- Interaction method: CLI for topic/schema setup + Flink SQL statements via REST API
+- Plan-before-execute: skill must present all operations and wait for confirmation
+- Sample data for testing
+
+The skill includes:
+- Step-by-step instructions with specific CLI commands and API calls in order
+- Schema definitions
+- Flink SQL join statement
+- Link to https://docs.confluent.io/cloud/current/flink/reference/queries/joins.md
+
+**Step 4 — Validate spec compliance:**
+- `name`: `confluent-cloud-order-enrichment` — lowercase+hyphens, includes platform, matches directory
+- `description`: under 1024 chars, includes what + when + Confluent Cloud target
+- `metadata`: author: confluent, version: "1.0"
+- SKILL.md body under 500 lines
+- `evals/evals.json` exists with test cases
+- `.env.template` exists
+
+**Step 5 — Set up environment:**
+- Test against Confluent Cloud (matches target platform)
+- Create .env.template with BOOTSTRAP_SERVERS, API keys, SR URL, Flink pool
+- Wait for user to fill in credentials
+
+**Step 6 — Create test and show plan:**
+```
+Plan for test case: order-enrichment-e2e
+
+Environment: Confluent Cloud
+Interaction method: CLI + REST API
+
+Operations (in execution order):
+1. Check Flink compute pool availability
+   Command: confluent flink compute-pool describe lfcp-xxxxx
+2. Pre-create topics
+   Command: confluent kafka topic create orders --partitions 3
+   Command: confluent kafka topic create customers --partitions 3
+   Command: confluent kafka topic create enriched_orders --partitions 3
+3. Register JSON schemas for all topics
+   Endpoint: POST /subjects/orders-value/versions
+4. Execute Flink SQL: CREATE TABLE + INSERT query for enrichment
+   Endpoint: POST /sql/v1/organizations/{org}/environments/{env}/statements
+5. Produce 10 sample orders and 5 sample customers
+   Script: python scripts/produce_data.py
+6. Verify 5 enriched orders appear in enriched_orders topic
+   Script: python scripts/consume_and_verify.py
+7. Cleanup: stop Flink statement (topics remain)
+
+Proceed? [yes/no]
+```
+
+**Step 7-8 — Run tests, evaluate, iterate:**
+- Spawn with-skill and without-skill subagents
+- Draft assertions: "5 enriched orders produced", "All orders have customer name/email", etc.
+- User reviews in browser, improve based on feedback
+
+**Step 9 — Optimize description:**
+- Run trigger optimization
+- Final description includes: "real-time enrichment", "Flink SQL", "join", "order data", "Confluent Cloud"
+
+**Step 10 — Package:**
+- Bundle with `produce_data.py`, `consume_and_verify.py`, `check_compute_pool.py`
+- Include the credential template (`.env.template` or `credentials.yaml.template`) and evals/
+- Run `skills-ref validate ./confluent-cloud-order-enrichment`
+- Deliver .skill file

--- a/skills/confluent-skill-creator/references/plan-template.md
+++ b/skills/confluent-skill-creator/references/plan-template.md
@@ -1,0 +1,73 @@
+# CRUD Operations Plan Template
+
+Before running any test or performing any resource-modifying operation, create a plan and get user confirmation.
+
+## Template
+
+```
+Plan for test case: <test-name>
+
+Environment: <local/platform/cloud/warpstream>
+Interaction method: <MCP tools / CLI / REST APIs / client libraries / combination>
+
+Operations (in execution order):
+
+1. <Operation description>
+   Tool/Command: <exact MCP tool name, CLI command, or API endpoint>
+   Example: `confluent kafka topic create orders --partitions 3`
+
+2. <Operation description>
+   Tool/Command: <exact tool/command>
+
+...
+
+Resources affected:
+- Topics: <list with partitions and retention>
+- Schemas: <list with format (JSON_SR | Avro | Protobuf)>
+- Flink resources: <compute pool, SQL statements> (if applicable)
+- Connectors: <connector names and types> (if applicable)
+
+Test data:
+- Produce N sample messages to <topic>
+- Verify expected output (N messages in <output-topic>)
+
+Cleanup (after verification):
+- <cleanup operations, noting which are local-only vs all-environment>
+
+Proceed with this plan? [yes/no]
+```
+
+**Wait for user confirmation.** Do not proceed without explicit approval.
+
+## Topic Management Rules
+
+- **Confluent Cloud**: Topics must be pre-created by the user. Check if they exist before testing. If missing, tell the user which topics need to be created.
+- **Local Confluent**: Auto-create topics during testing. Include auto-creation in the plan.
+- **Confluent Platform**: Ask user preference (pre-create or auto-create).
+- **WarpStream**: Topics can be auto-created. Note that `replication.factor` is cosmetic (hard-coded to 3).
+
+## Interaction Method Examples
+
+**MCP tools** (use fully qualified names — `ServerName:tool_name` — the server name depends on the user's MCP config):
+```
+1. List existing topics
+   Tool: confluent-local-oauth:list-topics (environment_id: env-xxx, cluster_id: lkc-xxx)
+2. Create orders topic
+   Tool: confluent-local-oauth:create-topics (topics: [{topic: "orders", numPartitions: 3}])
+```
+
+**CLI:**
+```
+1. Create orders topic
+   Command: confluent kafka topic create orders --partitions 3 --cluster lkc-xxx
+2. Register schema
+   Command: confluent schema-registry schema create --subject orders-value --schema schema.json
+```
+
+**REST API:**
+```
+1. Create topic via Kafka REST
+   Endpoint: POST /kafka/v3/clusters/{cluster_id}/topics
+2. Register schema via SR API
+   Endpoint: POST /subjects/orders-value/versions
+```

--- a/skills/confluent-skill-creator/references/schema-guid-header.md
+++ b/skills/confluent-skill-creator/references/schema-guid-header.md
@@ -1,0 +1,43 @@
+# Schema GUID in Header Configuration
+
+The default serialization format is JSON with Schema GUID in header (`JSON_SR`). The message payload remains pure JSON while a 16-byte schema GUID is stored in the Kafka message header (instead of prepending a magic byte + schema ID to the payload). Deserializers automatically check the header first, then fall back to the payload prefix for backward compatibility.
+
+For details, see [Wire format: schema GUID in header](https://docs.confluent.io/cloud/current/sr/fundamentals/serdes-develop/index.md).
+
+## Java Client Configuration
+
+```properties
+# Producer config
+key.serializer=io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer
+value.serializer=io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer
+key.schema.id.serializer=io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer
+value.schema.id.serializer=io.confluent.kafka.serializers.schema.id.HeaderSchemaIdSerializer
+
+# Consumer config (checks header first, then payload prefix)
+key.deserializer=io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer
+value.deserializer=io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer
+key.schema.id.deserializer=io.confluent.kafka.serializers.schema.id.HeaderSchemaIdDeserializer
+value.schema.id.deserializer=io.confluent.kafka.serializers.schema.id.HeaderSchemaIdDeserializer
+```
+
+## Confluent Cloud Managed Connectors
+
+```
+output.data.format=JSON_SR
+output.key.format=JSON_SR
+```
+
+## Why Schema GUID in Header?
+
+- Payload remains pure JSON — readable by any JSON consumer without Confluent deserializers
+- Schema enforcement still happens via Schema Registry
+- Easier migration for clients not currently using Schema Registry
+- Two identical schemas always produce the same GUID regardless of which Schema Registry they're registered with
+
+## Limitations
+
+See [docs](https://docs.confluent.io/cloud/current/sr/fundamentals/serdes-develop/index.md):
+
+- Headers may be dropped in Kafka Streams or ksqlDB state stores
+- Verify Kafka Connect preserves headers and doesn't transform them
+- Changing from payload prefix to header for record keys may alter partitioning

--- a/skills/confluent-skill-creator/scripts/check_compute_pool.py
+++ b/skills/confluent-skill-creator/scripts/check_compute_pool.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+Check if a Flink compute pool is available and has capacity.
+
+Usage:
+    python check_compute_pool.py --pool-id <pool-id>
+
+Environment variables required:
+    CONFLUENT_CLOUD_API_KEY
+    CONFLUENT_CLOUD_API_SECRET
+    FLINK_API_KEY (optional, for detailed pool info)
+    FLINK_API_SECRET (optional, for detailed pool info)
+"""
+
+import argparse
+import os
+import sys
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+def check_compute_pool(pool_id: str, cloud_api_key: str, cloud_api_secret: str) -> dict:
+    """
+    Check Flink compute pool status.
+
+    Returns dict with:
+        - available: bool
+        - status: str (PROVISIONING, RUNNING, FAILED, etc.)
+        - capacity: dict with current/max values
+        - message: str (human-readable status)
+    """
+    base_url = "https://api.confluent.cloud"
+    endpoint = f"/fcpm/v2/compute-pools/{pool_id}"
+
+    try:
+        response = requests.get(
+            f"{base_url}{endpoint}",
+            auth=HTTPBasicAuth(cloud_api_key, cloud_api_secret),
+            headers={"Content-Type": "application/json"},
+            timeout=10
+        )
+
+        if response.status_code == 404:
+            return {
+                "available": False,
+                "status": "NOT_FOUND",
+                "capacity": {},
+                "message": f"Compute pool {pool_id} not found"
+            }
+
+        response.raise_for_status()
+        data = response.json()
+
+        status = data.get("status", {}).get("phase", "UNKNOWN")
+        spec = data.get("spec", {})
+
+        # Check if pool is running
+        available = status == "RUNNING"
+
+        # Get capacity info if available
+        capacity = {}
+        if "max_cfu" in spec:
+            capacity["max_cfu"] = spec["max_cfu"]
+
+        message = f"Pool {pool_id} status: {status}"
+        if not available:
+            if status == "PROVISIONING":
+                message += " (still provisioning, wait a few minutes)"
+            elif status == "FAILED":
+                message += " (failed, check Confluent Cloud UI for details)"
+
+        return {
+            "available": available,
+            "status": status,
+            "capacity": capacity,
+            "message": message
+        }
+
+    except requests.exceptions.RequestException as e:
+        return {
+            "available": False,
+            "status": "ERROR",
+            "capacity": {},
+            "message": f"Error checking pool: {str(e)}"
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Check Flink compute pool availability")
+    parser.add_argument("--pool-id", required=True, help="Flink compute pool ID")
+    args = parser.parse_args()
+
+    # Get credentials from environment
+    cloud_api_key = os.getenv("CONFLUENT_CLOUD_API_KEY")
+    cloud_api_secret = os.getenv("CONFLUENT_CLOUD_API_SECRET")
+
+    if not cloud_api_key or not cloud_api_secret:
+        print("ERROR: Missing CONFLUENT_CLOUD_API_KEY or CONFLUENT_CLOUD_API_SECRET", file=sys.stderr)
+        print("Please set these in your .env file", file=sys.stderr)
+        sys.exit(1)
+
+    # Check the pool
+    result = check_compute_pool(args.pool_id, cloud_api_key, cloud_api_secret)
+
+    # Print results
+    print(result["message"])
+
+    if result["available"]:
+        print("✓ Compute pool is available and ready")
+        if result["capacity"]:
+            print(f"  Max CFU: {result['capacity'].get('max_cfu', 'unknown')}")
+        sys.exit(0)
+    else:
+        print("✗ Compute pool is not available")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/confluent-skill-creator/scripts/cleanup_resources.py
+++ b/skills/confluent-skill-creator/scripts/cleanup_resources.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+Clean up Confluent resources after testing (LOCAL ONLY).
+
+IMPORTANT: This script should only be used for local Confluent environments.
+For Confluent Cloud, resources should be manually reviewed and deleted.
+
+Usage:
+    python cleanup_resources.py --topics <topic1,topic2> [--schemas <subject1,subject2>]
+
+Environment variables required:
+    BOOTSTRAP_SERVERS
+    CLUSTER_API_KEY
+    CLUSTER_API_SECRET
+    SCHEMA_REGISTRY_URL (optional, for schema cleanup)
+    SCHEMA_REGISTRY_API_KEY (optional, for schema cleanup)
+    SCHEMA_REGISTRY_API_SECRET (optional, for schema cleanup)
+"""
+
+import argparse
+import os
+import sys
+from confluent_kafka.admin import AdminClient, NewTopic
+from confluent_kafka.schema_registry import SchemaRegistryClient
+
+
+def delete_topics(admin_client: AdminClient, topics: list) -> bool:
+    """Delete Kafka topics. Returns True if successful."""
+    try:
+        # Delete topics
+        fs = admin_client.delete_topics(topics, operation_timeout=30)
+
+        # Wait for deletion
+        for topic, f in fs.items():
+            try:
+                f.result()
+                print(f"✓ Deleted topic: {topic}")
+            except Exception as e:
+                print(f"✗ Failed to delete topic {topic}: {e}", file=sys.stderr)
+                return False
+
+        return True
+
+    except Exception as e:
+        print(f"✗ Error deleting topics: {e}", file=sys.stderr)
+        return False
+
+
+def deprecate_schemas(sr_client: SchemaRegistryClient, subjects: list) -> bool:
+    """
+    Soft-delete (deprecate) schemas rather than hard-deleting.
+    This is safer and follows Confluent best practices.
+    """
+    success = True
+    for subject in subjects:
+        try:
+            # Get all versions
+            versions = sr_client.get_versions(subject)
+
+            # Delete each version (soft delete)
+            for version in versions:
+                sr_client.delete_version(subject, str(version))
+                print(f"✓ Deprecated schema: {subject} version {version}")
+
+        except Exception as e:
+            print(f"✗ Failed to deprecate schema {subject}: {e}", file=sys.stderr)
+            success = False
+
+    return success
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Clean up Confluent test resources (LOCAL ONLY)")
+    parser.add_argument("--topics", help="Comma-separated list of topics to delete")
+    parser.add_argument("--schemas", help="Comma-separated list of schema subjects to deprecate")
+    parser.add_argument("--force", action="store_true",
+                       help="Skip confirmation prompt (use with caution)")
+    args = parser.parse_args()
+
+    if not args.topics and not args.schemas:
+        print("ERROR: Must specify --topics or --schemas to clean up", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse lists
+    topics = [t.strip() for t in args.topics.split(',')] if args.topics else []
+    schemas = [s.strip() for s in args.schemas.split(',')] if args.schemas else []
+
+    # Safety check: confirm this is local environment
+    bootstrap_servers = os.getenv("BOOTSTRAP_SERVERS", "")
+    if "confluent.cloud" in bootstrap_servers or "ccloud" in bootstrap_servers:
+        print("=" * 60, file=sys.stderr)
+        print("WARNING: This appears to be Confluent Cloud!", file=sys.stderr)
+        print("This cleanup script is intended for LOCAL environments only.", file=sys.stderr)
+        print("=" * 60, file=sys.stderr)
+        print("\nFor Confluent Cloud, manually delete resources via:", file=sys.stderr)
+        print("  - Confluent Cloud UI (https://confluent.cloud)", file=sys.stderr)
+        print("  - Confluent CLI: confluent kafka topic delete <topic>", file=sys.stderr)
+        print("\nDo NOT proceed unless you're absolutely sure.", file=sys.stderr)
+
+        if not args.force:
+            response = input("\nType 'DELETE' to proceed anyway: ")
+            if response != "DELETE":
+                print("Aborted.")
+                sys.exit(0)
+
+    # Confirmation prompt
+    if not args.force:
+        print("Resources to clean up:")
+        if topics:
+            print(f"  Topics: {', '.join(topics)}")
+        if schemas:
+            print(f"  Schemas: {', '.join(schemas)}")
+
+        response = input("\nProceed? [y/N]: ")
+        if response.lower() != 'y':
+            print("Aborted.")
+            sys.exit(0)
+
+    # Clean up topics
+    if topics:
+        api_key = os.getenv("CLUSTER_API_KEY")
+        api_secret = os.getenv("CLUSTER_API_SECRET")
+
+        if not bootstrap_servers or not api_key or not api_secret:
+            print("ERROR: Missing Kafka credentials", file=sys.stderr)
+            sys.exit(1)
+
+        admin_conf = {
+            'bootstrap.servers': bootstrap_servers,
+            'security.protocol': 'SASL_SSL',
+            'sasl.mechanism': 'PLAIN',
+            'sasl.username': api_key,
+            'sasl.password': api_secret
+        }
+
+        admin_client = AdminClient(admin_conf)
+        success = delete_topics(admin_client, topics)
+
+        if not success:
+            print("Topic deletion failed", file=sys.stderr)
+            sys.exit(1)
+
+    # Clean up schemas
+    if schemas:
+        sr_url = os.getenv("SCHEMA_REGISTRY_URL")
+        sr_api_key = os.getenv("SCHEMA_REGISTRY_API_KEY")
+        sr_api_secret = os.getenv("SCHEMA_REGISTRY_API_SECRET")
+
+        if not sr_url or not sr_api_key or not sr_api_secret:
+            print("ERROR: Missing Schema Registry credentials", file=sys.stderr)
+            sys.exit(1)
+
+        schema_registry_conf = {
+            'url': sr_url,
+            'basic.auth.user.info': f'{sr_api_key}:{sr_api_secret}'
+        }
+        sr_client = SchemaRegistryClient(schema_registry_conf)
+
+        success = deprecate_schemas(sr_client, schemas)
+
+        if not success:
+            print("Schema deprecation failed", file=sys.stderr)
+            sys.exit(1)
+
+    print("\n✓ Cleanup completed successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/confluent-skill-creator/scripts/consume_and_verify.py
+++ b/skills/confluent-skill-creator/scripts/consume_and_verify.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Consume JSON_SR messages from a Kafka topic and verify against expectations.
+
+Usage:
+    python consume_and_verify.py --topic <topic-name> --expected-count <num> [--timeout <seconds>]
+
+Environment variables required:
+    BOOTSTRAP_SERVERS
+    CLUSTER_API_KEY
+    CLUSTER_API_SECRET
+    SCHEMA_REGISTRY_URL
+    SCHEMA_REGISTRY_API_KEY
+    SCHEMA_REGISTRY_API_SECRET
+
+Verification:
+    - Consumes messages from beginning
+    - Checks if expected count is met
+    - Outputs consumed messages as JSON
+    - Returns exit code 0 if verification passes, 1 otherwise
+"""
+
+import argparse
+import json
+import os
+import sys
+import time
+from confluent_kafka import DeserializingConsumer
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.json_schema import JSONDeserializer
+from confluent_kafka.serialization import StringDeserializer
+
+
+def create_consumer(bootstrap_servers: str, api_key: str, api_secret: str,
+                   schema_registry_url: str, sr_api_key: str, sr_api_secret: str,
+                   group_id: str) -> DeserializingConsumer:
+    """Create Kafka consumer with JSON_SR deserialization (schema ID in header)."""
+
+    # Schema Registry client
+    schema_registry_conf = {
+        'url': schema_registry_url,
+        'basic.auth.user.info': f'{sr_api_key}:{sr_api_secret}'
+    }
+    schema_registry_client = SchemaRegistryClient(schema_registry_conf)
+
+    # JSON deserializer (schema auto-fetched from SR via schema ID in header)
+    json_deserializer = JSONDeserializer(None, schema_registry_client=schema_registry_client)
+
+    # Consumer config
+    consumer_conf = {
+        'bootstrap.servers': bootstrap_servers,
+        'security.protocol': 'SASL_SSL',
+        'sasl.mechanism': 'PLAIN',
+        'sasl.username': api_key,
+        'sasl.password': api_secret,
+        'group.id': group_id,
+        'auto.offset.reset': 'earliest',
+        'enable.auto.commit': False,
+        'key.deserializer': StringDeserializer('utf_8'),
+        'value.deserializer': json_deserializer,
+        'client.id': 'consume-and-verify'
+    }
+
+    return DeserializingConsumer(consumer_conf)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Consume and verify JSON_SR messages")
+    parser.add_argument("--topic", required=True, help="Kafka topic name")
+    parser.add_argument("--expected-count", type=int, help="Expected message count")
+    parser.add_argument("--timeout", type=int, default=30, help="Timeout in seconds (default: 30)")
+    parser.add_argument("--output", help="Output file for consumed messages (JSON)")
+    parser.add_argument("--verify-field", help="Field to verify exists in all messages")
+    args = parser.parse_args()
+
+    # Get credentials from environment
+    bootstrap_servers = os.getenv("BOOTSTRAP_SERVERS")
+    api_key = os.getenv("CLUSTER_API_KEY")
+    api_secret = os.getenv("CLUSTER_API_SECRET")
+    sr_url = os.getenv("SCHEMA_REGISTRY_URL")
+    sr_api_key = os.getenv("SCHEMA_REGISTRY_API_KEY")
+    sr_api_secret = os.getenv("SCHEMA_REGISTRY_API_SECRET")
+
+    missing = []
+    if not bootstrap_servers:
+        missing.append("BOOTSTRAP_SERVERS")
+    if not api_key:
+        missing.append("CLUSTER_API_KEY")
+    if not api_secret:
+        missing.append("CLUSTER_API_SECRET")
+    if not sr_url:
+        missing.append("SCHEMA_REGISTRY_URL")
+    if not sr_api_key:
+        missing.append("SCHEMA_REGISTRY_API_KEY")
+    if not sr_api_secret:
+        missing.append("SCHEMA_REGISTRY_API_SECRET")
+
+    if missing:
+        print(f"ERROR: Missing environment variables: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create consumer
+    group_id = f"verify-consumer-{int(time.time())}"
+    try:
+        consumer = create_consumer(
+            bootstrap_servers, api_key, api_secret,
+            sr_url, sr_api_key, sr_api_secret,
+            group_id
+        )
+    except Exception as e:
+        print(f"ERROR: Failed to create consumer: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Subscribe to topic
+    consumer.subscribe([args.topic])
+    print(f"Consuming from topic '{args.topic}' (timeout: {args.timeout}s)...")
+
+    messages = []
+    start_time = time.time()
+    verification_failed = False
+
+    try:
+        while time.time() - start_time < args.timeout:
+            msg = consumer.poll(timeout=1.0)
+
+            if msg is None:
+                continue
+
+            if msg.error():
+                print(f"Consumer error: {msg.error()}", file=sys.stderr)
+                continue
+
+            # Deserialize message
+            value = msg.value()
+            key = msg.key()
+
+            messages.append({
+                'key': key,
+                'value': value,
+                'partition': msg.partition(),
+                'offset': msg.offset(),
+                'timestamp': msg.timestamp()[1]
+            })
+
+            print(f"✓ Consumed message [{len(messages)}]: partition={msg.partition()}, offset={msg.offset()}")
+
+            # Verify field if specified
+            if args.verify_field and args.verify_field not in value:
+                print(f"✗ VERIFICATION FAILED: Field '{args.verify_field}' not found in message", file=sys.stderr)
+                verification_failed = True
+
+            # Check if we've reached expected count
+            if args.expected_count and len(messages) >= args.expected_count:
+                print(f"✓ Reached expected count ({args.expected_count})")
+                break
+
+    except KeyboardInterrupt:
+        print("\nConsumption interrupted by user")
+    finally:
+        consumer.close()
+
+    # Write output file
+    if args.output:
+        with open(args.output, 'w') as f:
+            json.dump(messages, f, indent=2, default=str)
+        print(f"✓ Wrote {len(messages)} messages to {args.output}")
+
+    # Print summary
+    print(f"\n--- Summary ---")
+    print(f"Messages consumed: {len(messages)}")
+    if args.expected_count:
+        print(f"Expected count: {args.expected_count}")
+        if len(messages) == args.expected_count:
+            print("✓ Count verification PASSED")
+        else:
+            print(f"✗ Count verification FAILED (expected {args.expected_count}, got {len(messages)})")
+            verification_failed = True
+
+    # Exit with appropriate code
+    if verification_failed:
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/confluent-skill-creator/scripts/produce_data.py
+++ b/skills/confluent-skill-creator/scripts/produce_data.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""
+Produce JSON_SR-encoded messages to a Kafka topic using Schema Registry.
+
+Uses JSON serializer with schema ID in header for schema enforcement.
+
+Usage:
+    python produce_data.py --topic <topic-name> --schema <schema-file> --data <data-file>
+
+Environment variables required:
+    BOOTSTRAP_SERVERS
+    CLUSTER_API_KEY
+    CLUSTER_API_SECRET
+    SCHEMA_REGISTRY_URL
+    SCHEMA_REGISTRY_API_KEY
+    SCHEMA_REGISTRY_API_SECRET
+
+Example data file (JSON array):
+    [
+        {"id": 1, "name": "Alice", "email": "alice@example.com"},
+        {"id": 2, "name": "Bob", "email": "bob@example.com"}
+    ]
+"""
+
+import argparse
+import json
+import os
+import sys
+from confluent_kafka import SerializingProducer
+from confluent_kafka.schema_registry import SchemaRegistryClient
+from confluent_kafka.schema_registry.json_schema import JSONSerializer
+
+
+def create_producer(bootstrap_servers: str, api_key: str, api_secret: str,
+                   schema_registry_url: str, sr_api_key: str, sr_api_secret: str,
+                   schema_str: str) -> SerializingProducer:
+    """Create Kafka producer with JSON_SR serialization (schema ID in header)."""
+
+    # Schema Registry client
+    schema_registry_conf = {
+        'url': schema_registry_url,
+        'basic.auth.user.info': f'{sr_api_key}:{sr_api_secret}'
+    }
+    schema_registry_client = SchemaRegistryClient(schema_registry_conf)
+
+    # JSON serializer with schema ID in header
+    json_serializer = JSONSerializer(
+        schema_str,
+        schema_registry_client,
+        conf={'auto.register.schemas': True}
+    )
+
+    # Producer config
+    producer_conf = {
+        'bootstrap.servers': bootstrap_servers,
+        'security.protocol': 'SASL_SSL',
+        'sasl.mechanism': 'PLAIN',
+        'sasl.username': api_key,
+        'sasl.password': api_secret,
+        'value.serializer': json_serializer,
+        'client.id': 'produce-json-sr-data'
+    }
+
+    return SerializingProducer(producer_conf)
+
+
+def delivery_callback(err, msg):
+    """Callback for message delivery reports."""
+    if err:
+        print(f'Message delivery failed: {err}', file=sys.stderr)
+    else:
+        print(f'Message delivered to {msg.topic()} [{msg.partition()}] @ {msg.offset()}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Produce JSON_SR messages to Kafka")
+    parser.add_argument("--topic", required=True, help="Kafka topic name")
+    parser.add_argument("--schema", required=True, help="Path to JSON schema file (.json)")
+    parser.add_argument("--data", required=True, help="Path to data file (JSON array)")
+    parser.add_argument("--key-field", help="Field to use as message key (optional)")
+    args = parser.parse_args()
+
+    # Get credentials from environment
+    bootstrap_servers = os.getenv("BOOTSTRAP_SERVERS")
+    api_key = os.getenv("CLUSTER_API_KEY")
+    api_secret = os.getenv("CLUSTER_API_SECRET")
+    sr_url = os.getenv("SCHEMA_REGISTRY_URL")
+    sr_api_key = os.getenv("SCHEMA_REGISTRY_API_KEY")
+    sr_api_secret = os.getenv("SCHEMA_REGISTRY_API_SECRET")
+
+    missing = []
+    if not bootstrap_servers:
+        missing.append("BOOTSTRAP_SERVERS")
+    if not api_key:
+        missing.append("CLUSTER_API_KEY")
+    if not api_secret:
+        missing.append("CLUSTER_API_SECRET")
+    if not sr_url:
+        missing.append("SCHEMA_REGISTRY_URL")
+    if not sr_api_key:
+        missing.append("SCHEMA_REGISTRY_API_KEY")
+    if not sr_api_secret:
+        missing.append("SCHEMA_REGISTRY_API_SECRET")
+
+    if missing:
+        print(f"ERROR: Missing environment variables: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
+
+    # Read schema
+    try:
+        with open(args.schema, 'r') as f:
+            schema_str = f.read()
+    except FileNotFoundError:
+        print(f"ERROR: Schema file not found: {args.schema}", file=sys.stderr)
+        sys.exit(1)
+
+    # Read data
+    try:
+        with open(args.data, 'r') as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        print(f"ERROR: Data file not found: {args.data}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Invalid JSON in data file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    if not isinstance(data, list):
+        print("ERROR: Data file must contain a JSON array", file=sys.stderr)
+        sys.exit(1)
+
+    # Create producer
+    try:
+        producer = create_producer(
+            bootstrap_servers, api_key, api_secret,
+            sr_url, sr_api_key, sr_api_secret,
+            schema_str
+        )
+    except Exception as e:
+        print(f"ERROR: Failed to create producer: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Produce messages
+    print(f"Producing {len(data)} messages to topic '{args.topic}'...")
+    produced = 0
+
+    for record in data:
+        try:
+            # Use key field if specified
+            key = str(record.get(args.key_field)) if args.key_field else None
+
+            producer.produce(
+                topic=args.topic,
+                key=key,
+                value=record,
+                on_delivery=delivery_callback
+            )
+            produced += 1
+
+        except Exception as e:
+            print(f"Failed to produce message: {e}", file=sys.stderr)
+
+    # Flush
+    print("Flushing producer...")
+    producer.flush()
+
+    print(f"\nSuccessfully produced {produced}/{len(data)} messages to '{args.topic}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/confluent-skill-creator/scripts/register_schema.py
+++ b/skills/confluent-skill-creator/scripts/register_schema.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+Register a JSON schema with Confluent Schema Registry.
+
+Usage:
+    python register_schema.py --subject <subject-name> --schema <schema-file>
+
+Environment variables required:
+    SCHEMA_REGISTRY_URL
+    SCHEMA_REGISTRY_API_KEY
+    SCHEMA_REGISTRY_API_SECRET
+
+Subject naming:
+    - For topic value schemas: <topic-name>-value
+    - For topic key schemas: <topic-name>-key
+"""
+
+import argparse
+import json
+import os
+import sys
+from confluent_kafka.schema_registry import SchemaRegistryClient, Schema
+
+
+def register_schema(sr_client: SchemaRegistryClient, subject: str, schema_str: str) -> int:
+    """
+    Register schema with Schema Registry.
+
+    Returns schema ID.
+    """
+    schema = Schema(schema_str, schema_type="JSON")
+    schema_id = sr_client.register_schema(subject, schema)
+    return schema_id
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Register JSON schema with Schema Registry")
+    parser.add_argument("--subject", required=True, help="Schema subject name (e.g., orders-value)")
+    parser.add_argument("--schema", required=True, help="Path to JSON schema file (.json)")
+    parser.add_argument("--check-compatibility", action="store_true",
+                       help="Check compatibility before registering")
+    args = parser.parse_args()
+
+    # Get credentials from environment
+    sr_url = os.getenv("SCHEMA_REGISTRY_URL")
+    sr_api_key = os.getenv("SCHEMA_REGISTRY_API_KEY")
+    sr_api_secret = os.getenv("SCHEMA_REGISTRY_API_SECRET")
+
+    if not sr_url or not sr_api_key or not sr_api_secret:
+        print("ERROR: Missing Schema Registry credentials", file=sys.stderr)
+        print("Required: SCHEMA_REGISTRY_URL, SCHEMA_REGISTRY_API_KEY, SCHEMA_REGISTRY_API_SECRET",
+              file=sys.stderr)
+        sys.exit(1)
+
+    # Read schema file
+    try:
+        with open(args.schema, 'r') as f:
+            schema_str = f.read()
+            # Validate it's valid JSON
+            json.loads(schema_str)
+    except FileNotFoundError:
+        print(f"ERROR: Schema file not found: {args.schema}", file=sys.stderr)
+        sys.exit(1)
+    except json.JSONDecodeError as e:
+        print(f"ERROR: Invalid JSON in schema file: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Create Schema Registry client
+    schema_registry_conf = {
+        'url': sr_url,
+        'basic.auth.user.info': f'{sr_api_key}:{sr_api_secret}'
+    }
+    sr_client = SchemaRegistryClient(schema_registry_conf)
+
+    # Check compatibility if requested
+    if args.check_compatibility:
+        try:
+            schema = Schema(schema_str, schema_type="JSON")
+            is_compatible = sr_client.test_compatibility(args.subject, schema)
+            if is_compatible:
+                print(f"✓ Schema is compatible with existing versions of '{args.subject}'")
+            else:
+                print(f"✗ Schema is NOT compatible with existing versions of '{args.subject}'",
+                     file=sys.stderr)
+                print("Fix compatibility issues or update compatibility mode", file=sys.stderr)
+                sys.exit(1)
+        except Exception as e:
+            # Subject might not exist yet, which is fine
+            print(f"Note: Could not check compatibility (subject might not exist): {e}")
+
+    # Register schema
+    try:
+        schema_id = register_schema(sr_client, args.subject, schema_str)
+        print(f"✓ Schema registered successfully")
+        print(f"  Subject: {args.subject}")
+        print(f"  Schema ID: {schema_id}")
+        sys.exit(0)
+    except Exception as e:
+        print(f"✗ Failed to register schema: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/confluent-skill-creator/scripts/requirements.txt
+++ b/skills/confluent-skill-creator/scripts/requirements.txt
@@ -1,0 +1,13 @@
+# Python dependencies for Confluent skill creator scripts
+
+# Confluent Kafka Python client with Schema Registry support
+confluent-kafka[avro,json,protobuf]>=2.3.0
+
+# HTTP requests for Confluent Cloud API
+requests>=2.31.0
+
+# JSON Schema support (if using JSON_SR)
+jsonschema>=4.20.0
+
+# For loading environment variables
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Description

Adds the **confluent-skill-creator** skill — a meta-skill for authoring new Confluent-specific skills that are tested against real Confluent environments (Confluent Cloud, Confluent Platform, Apache Kafka, or WarpStream). It guides scope/platform targeting, intent capture, spec-compliant authoring, credential setup, end-to-end testing with bundled scripts, eval-driven iteration, and packaging. It is for *building* new skills — not for using existing product skills.

Ported from the internal `confluent-agent-toolkit` with the following changes:

- **Docs links use `.md`, not `.html`** — docs.confluent.io serves clean Markdown at the same path, which is easier for agents to consume. The skill now documents this preference for skills it generates, and all links were validated as live.
- **YAML credential support** — credentials can now be supplied as `credentials.yaml` in addition to `.env`. Added `references/credential-templates.md` (teaches both formats) and a `credentials.yaml.template`.
- **Removed READMEs** — dropped the skill `README.md` and `scripts/README.md` to match this repo's convention (skills ship `SKILL.md` + `references/` + `evals/` only). The old README's Support section was removed with it.
- **New "Skill Anatomy and Progressive Disclosure" section** — anatomy tree (`scripts/`/`references/`/`assets/`), the three-level loading model, domain organization by variant, and the lack-of-surprise safety principle. SKILL.md remains under 500 lines (417).
- Added `confluent-skill-creator` to the README skills table; whitelisted `*.yaml.template` in `.gitignore` (consistent with the existing `!.env.template` exception) so the credential template is tracked.

## Docs

- [ ] If adding a new skill, I have reached out to reviewers to make sure the docs are updated to reflect the new skill.

## Testing

- [ ] Evals pass at 90%+ threshold <!-- evals/evals.json ported as-is; run evals to confirm the score before merge -->

## Review

- [ ] SME reviewer identified if adding a new skill: <!-- @mention here -->
- [ ] DTX/DevRel reviewer assigned

## Additional Context

Source: `confluentinc/internal-agent-toolkit` → `skills/confluent-skill-creator`. Companion to the existing `confluent-skill-reviewer` skill in this repo.
