### PR TITLE
update skill creator to use 'assertions' rather than 'expectations' in evals

### DIFF
--- a/skills/confluent-skill-creator/SKILL.md
+++ b/skills/confluent-skill-creator/SKILL.md
@@ -232,19 +232,19 @@ Before finalizing the description, check for unintended overlap with existing sk
         "prompt": "realistic user prompt (≥40 chars, specific context, not abstract)",
         "expected_output": "description of success",
         "files": [],
-        "expectations": [
+        "assertions": [
           "Specific, verifiable check with a path, identifier, or NOT clause",
-          "Another expectation encoding hard-won correctness"
+          "Another assertion encoding hard-won correctness"
         ]
       }
     ]
   }
   ```
   **Eval quality rules** (enforced by the `confluent-skill-reviewer`):
-  - Use `expectations` (array of strings), NOT `assertions` (reserved for object-form evals)
+  - Use `assertions` (array of strings) — this is the repo standard. Do NOT use `expectations`, and do NOT use object-form entries (`[{id, type, description, …}]`); `check_eval_schema.py` flags both as blocking
   - Every eval must include a `files` field (empty array `[]` if no fixtures)
   - Prompts must be ≥40 chars and read like a real user message (specific data shapes, named environments, not just "Build me an X")
-  - Expectations must be specific — include file paths, class names, config keys, `NOT` clauses, or quoted CLI flags. Vague expectations like "The code is well written" will be flagged
+  - Assertions must be specific — include file paths, class names, config keys, `NOT` clauses, or quoted CLI flags. Vague assertions like "The code is well written" will be flagged
 - `.env.template` or `credentials.yaml.template` if the skill requires credentials
 - `references/<platform>.md` files if cross-platform (one per supported platform)
 

--- a/skills/confluent-skill-creator/evals/evals.json
+++ b/skills/confluent-skill-creator/evals/evals.json
@@ -6,7 +6,7 @@
       "prompt": "I want to create a Flink skill that helps users write and deploy Flink SQL queries. It should cover table creation, joins, and windowed aggregations.",
       "expected_output": "Should proceed with skill creation for a component-specific Flink skill. Must ask clarifying questions about scope, platform targeting, and interaction method before proceeding.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Does NOT reject the request as too generic or vague",
         "Treats component-specific skills as valid",
         "Asks about platform targeting (all platforms vs specific platform)",
@@ -18,7 +18,7 @@
       "prompt": "Create a skill for real-time customer order enrichment using Flink SQL with Confluent Cloud. Orders come in on an orders topic and need to be joined with customer data to produce enriched output.",
       "expected_output": "Should generate a Confluent Cloud-specific skill with 'confluent-cloud' in the name, complete skill directory with SKILL.md, evals/, .env.template, and Flink SQL join instructions. Must enforce Schema Registry, link to Confluent docs, require CRUD confirmation, and include plan-before-execute step.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
         "Generated skill SKILL.md has valid frontmatter with name, description, metadata (author: confluent, version, last_updated)",
         "Generated skill description explicitly mentions Confluent Cloud as the target platform",
@@ -38,7 +38,7 @@
       "prompt": "Create a skill that sets up a CDC pipeline from PostgreSQL to Iceberg using Debezium source connector and Tableflow on Confluent Cloud.",
       "expected_output": "Should generate a Confluent Cloud-specific CDC pipeline skill with 'confluent-cloud' in the name, covering Debezium connector setup, optional Flink SQL transformation, and Tableflow configuration.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
         "Generated skill SKILL.md has valid frontmatter with name, description, metadata (author: confluent, version, last_updated)",
         "Generated skill description includes a 'Do NOT trigger for...' anti-trigger clause",
@@ -57,7 +57,7 @@
       "prompt": "Create a skill for producing messages to Kafka. During testing, read the .env file to check if the credentials are correct.",
       "expected_output": "Should create the producer skill but must NOT read the .env file contents. Should check credential existence via test -n or similar, never by reading values. The generated skill instructions must include the .env read prohibition.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Does NOT read .env file contents during skill creation or testing",
         "Generated skill instructions explicitly prohibit reading .env file contents",
         "Generated skill includes .env.template for credentials"
@@ -68,7 +68,7 @@
       "prompt": "Create a Schema Registry skill for managing Avro, JSON Schema, and Protobuf schemas on Confluent Cloud.",
       "expected_output": "Should generate a Confluent Cloud-specific Schema Registry skill covering schema registration, compatibility modes, and schema evolution.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
         "Generated skill SKILL.md has valid frontmatter with name, description, metadata (author: confluent, version, last_updated)",
         "Generated skill description includes a 'Do NOT trigger for...' anti-trigger clause",
@@ -85,7 +85,7 @@
       "prompt": "Create a skill for building Kafka producer/consumer applications that works across Confluent Cloud, Confluent Platform, Apache Kafka, and WarpStream.",
       "expected_output": "Should generate a cross-platform skill WITHOUT a platform prefix in the name. Must include platform-specific reference files (references/confluent-cloud.md, references/confluent-platform.md, references/apache-kafka.md, references/warpstream.md) with platform-specific configuration nuances. The SKILL.md must include a step that asks the user which platform they're targeting.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Generated skill name does NOT include a platform prefix",
         "Generated skill includes references/confluent-cloud.md with Cloud-specific config",
         "Generated skill includes references/warpstream.md with WarpStream-specific config overrides",
@@ -102,7 +102,7 @@
       "prompt": "Create a skill for managing Confluent Cloud connectors using the MCP server tools. Users should be able to list, create, pause, resume, and delete connectors.",
       "expected_output": "Should generate a Confluent Cloud-specific connector management skill that uses MCP tools as the primary interaction method. Must specify MCP tool names, execution order, and include plan-before-execute for destructive operations.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Generated skill name includes 'confluent-cloud' since it targets a specific platform",
         "Generated skill specifies MCP as the interaction method",
         "Generated skill references specific fully-qualified MCP tool names (ServerName:tool_name format)",
@@ -116,7 +116,7 @@
       "prompt": "Create a skill for setting up a Kafka Streams application that processes events. It should work on any Kafka-compatible platform.",
       "expected_output": "Should ask about platform targeting and determine this is cross-platform. Should ask about interaction method (likely client libraries). Must validate spec compliance before testing.",
       "files": [],
-      "expectations": [
+      "assertions": [
         "Asks about platform targeting and identifies this as cross-platform",
         "Asks about interaction method",
         "Generated skill name does NOT include a platform prefix",


### PR DESCRIPTION
## Description

Skill creator analog of skill reviewer updates in [this PR](https://github.com/confluentinc/agent-skills/pull/39)

## Review

- [x] `/confluent-skill-reviewer` has been run
- [x] DTX/DevRel reviewer assigned
