### PR TITLE
chore: add metadata.version to frontmatter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,11 @@
 
 - [ ] If adding a new skill, I have reached out to reviewers to make sure the docs are updated to reflect the new skill.
 
+## Versioning
+
+- [ ] `metadata.version` bumped in any changed skill's `SKILL.md` (PATCH for non-behavioral fixes, MINOR for new capability, MAJOR for breaking changes)
+- [ ] If any skill received a MINOR or MAJOR bump: `version` updated in both `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json`
+
 ## Testing
 
 - [ ] Evals pass at 90%+ threshold

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,3 +59,21 @@ Requires Python 3.10+. No other build tooling is needed for skill development.
 ## Adding a new skill
 
 Create `skills/<name>/` with `SKILL.md` (frontmatter — `name`, `description` with triggers + anti-triggers — and a body that routes to `references/*.md` at decision points), `evals/evals.json` with prompts and `expectations[]`, and any `scripts/`. The plugin manifests in `.claude-plugin/` and `.cursor-plugin/` point at `./skills/` so new skills are auto-discovered — no manifest edit needed. Add the skill to the table in `README.md`. The PR template requires an SME reviewer plus a DTX/DevRel reviewer for new skills.
+
+## Versioning
+
+There are two levels of version that must be kept in sync.
+
+**Skill-level version** (`metadata.version` in `SKILL.md` frontmatter):
+
+| Bump | When |
+|------|------|
+| PATCH (`x.y.Z`) | Non-behavioral: typos, wording clarifications, reference content corrections that don't change what the skill does or produces |
+| MINOR (`x.Y.0`) | Additive: new modes, new reference files, new behavior branches, new eval cases for newly supported scenarios |
+| MAJOR (`X.0.0`) | Breaking: trigger `description` overhaul that changes which prompts the skill handles, removed modes or features, significant behavioral shifts |
+
+**Plugin-level version** (`.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json`):
+
+- Bump whenever any skill in the repo receives a MINOR or MAJOR version bump.
+- Both files must be updated together and kept in sync with each other.
+- A PR that only bumps individual skill PATCH versions does **not** require a plugin-level bump.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -314,6 +314,20 @@ Verify your skill triggers correctly:
    - Configurations are valid
    - Best practices are followed
 
+## Versioning
+
+Every skill carries a `metadata.version` field in its `SKILL.md` frontmatter. Bump it in the same PR as the change that warrants it.
+
+| Bump | When |
+|------|------|
+| PATCH (`x.y.Z`) | Non-behavioral: typos, wording clarifications, reference content corrections that don't change what the skill does |
+| MINOR (`x.Y.0`) | Additive: new modes, new reference files, new behavior branches, new eval cases for newly supported scenarios |
+| MAJOR (`X.0.0`) | Breaking: trigger `description` overhaul that changes which prompts the skill handles, removed modes or features, significant behavioral shifts |
+
+If your change bumps any skill to a MINOR or MAJOR version, also bump the `version` field in **both** `.claude-plugin/plugin.json` and `.cursor-plugin/plugin.json` — these two files must always match. A PATCH-only change does not require a plugin-level bump.
+
+New skills start at `1.0.0`.
+
 ## Submitting a Pull Request
 
 Ensure the following before opening a pull request:

--- a/skills/confluent-cloud-cdc-tableflow/SKILL.md
+++ b/skills/confluent-cloud-cdc-tableflow/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: confluent-cloud-cdc-tableflow
 description: Set up end-to-end Change Data Capture (CDC) pipelines on Confluent Cloud using Debezium source connectors, Flink for transformation, and Tableflow for data lake integration. Supports JSON_SR, Avro, and Protobuf formats. Handles schemaless topics (plain JSON without SR) and multi-event topics. This skill handles the complete workflow from database to Iceberg/Delta tables. Use this skill when users want to capture database changes and materialize them into Iceberg or Delta Lake tables via Confluent Cloud Tableflow. Trigger phrases include "CDC to Tableflow", "database to Iceberg", "database to Delta Lake", "stream database changes to data lake", "set up Tableflow pipeline", "schemaless topic to Tableflow", or "multi-event topic to Iceberg". Do NOT trigger for general CDC, Debezium, or database replication requests that do not involve Tableflow or Iceberg/Delta Lake as the destination.
+metadata:
+  version: "1.0.0"
 ---
 
 # Confluent Cloud CDC to Tableflow Pipeline

--- a/skills/confluent-skill-creator/SKILL.md
+++ b/skills/confluent-skill-creator/SKILL.md
@@ -4,7 +4,7 @@ description: Create Confluent-specific skills for external users. Use this skill
 compatibility: Requires Python 3.9+, confluent-kafka, fastavro, requests. Needs access to a Confluent environment (Cloud, Platform, local Docker, or WarpStream) for E2E testing.
 metadata:
   author: confluent
-  version: "1.0"
+  version: "1.0.0"
   last_updated: "2026-05-12"
 ---
 

--- a/skills/confluent-skill-reviewer/SKILL.md
+++ b/skills/confluent-skill-reviewer/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: confluent-skill-reviewer
 description: Review a Confluent agent skill in this repo against the Agent Skills spec (agentskills.io), Confluent conventions in CLAUDE.md, the PR template gates, and the evals-as-contract rule. Use this skill whenever the user asks to review, audit, validate, or lint a skill; opens or inspects a PR that adds or modifies anything under `skills/`; asks about spec conformance, lazy-loading, frontmatter shape, trigger overlap, or eval coverage; or wants a pre-merge sanity check on skill changes. Do NOT trigger for general code review of application code; security review; auditing schemas, producer/consumer configs, PII tagging, or Terraform generation for Schema Registry (handled by `kafka-schema-registry`); runtime/log analysis of skill behavior (use `tools/skill_review_dashboard.py`); or any changes that don't touch the `skills/` tree.
+metadata:
+  version: "1.0.0"
 ---
 
 # confluent-skill-reviewer — audit a Confluent agent skill

--- a/skills/developing-kafka-python-client/SKILL.md
+++ b/skills/developing-kafka-python-client/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: developing-kafka-python-client
 description: "Use when the user wants to build a Python Kafka producer or consumer, add Schema Registry to existing Python code, migrate from raw JSON to schema-backed serialization, or scaffold a confluent-kafka-python project for Confluent Cloud, local Docker, or WarpStream. Also use when user wants to optimize Python Kafka client configuration for WarpStream."
+metadata:
+  version: "1.0.0"
 ---
 
 <HARD-GATE>

--- a/skills/flink-udf/SKILL.md
+++ b/skills/flink-udf/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: flink-udf
 description: "Build and deploy Apache Flink user-defined functions (UDFs) in Java for stream processing over Kafka. Use this skill when users want to create scalar UDFs, user-defined table functions (UDTFs), or process table functions (PTFs) in Java, deploy them to Confluent Cloud or local Docker environments, and invoke them from Flink SQL or the Table API. Trigger on: Flink UDF, custom Flink function, process table function, PTF, UDTF, Flink user defined, extend Flink SQL, stateful stream processing with Flink. Do NOT trigger for: Kafka Streams UDFs (use kafka-streams-programming skill), general Flink job development without custom functions, CDC streaming data piplines that include Flink (prefer the confluent-cloud-cdc-tableflow skill), Flink connector setup, or Kafka producer/consumer code."
+metadata:
+  version: "1.0.0"
 ---
 
 # Flink User-Defined Functions (UDFs)

--- a/skills/kafka-schema-registry/SKILL.md
+++ b/skills/kafka-schema-registry/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: kafka-schema-registry
 description: Scan a project to identify Kafka applications, extract schemas from data models, tag PII fields, generate Terraform for Confluent Schema Registry registration, and produce a migration report with rollout ordering. Use this skill when a user asks to analyze a folder or repo for Kafka usage, extract schemas, audit producer/consumer configurations, or generate Terraform for Schema Registry.
+metadata:
+  version: "1.0.0"
 ---
 
 # Kafka Schema Registry Skill

--- a/skills/kafka-streams-programming/SKILL.md
+++ b/skills/kafka-streams-programming/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: kafka-streams-programming
 description: Architect, build, and debug Kafka Streams apps (JVM-embedded stream processing). Use when user mentions KStream, KTable, topology, TopologyTestDriver, StreamsBuilder, interactive queries, GlobalKTable, joins/windows/aggregations, or debugging issues (rebalancing, state stores, lag, deserialization errors). Also use when user wants to optimize Kafka Streams for WarpStream or tune Kafka Streams client configuration for WarpStream. Do NOT trigger for Flink, connectors, CDC, or plain producer/consumer.
+metadata:
+  version: "1.0.0"
 ---
 
 # Kafka Streams — Architect, Build, Debug


### PR DESCRIPTION
## Description

Adds a version to the frontmatter in each skill as seen here https://agentskills.io/specification 

I updated the confluent-skill-creator, which already had a version, to use full semantic versioning 
