### PR TITLE
disable Semaphore jobs that are n/a for tags

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "streaming-skills-plugin",
   "description": "Skills for streaming application developers, covering Kafka and Flink client libraries and Schema Registry",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "skills": "./skills/"
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "confluent-streaming-skills",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Skills for streaming application developers, covering Kafka and Flink client libraries and Schema Registry.",
   "author": {
     "name": "Confluent"

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -74,7 +74,7 @@ blocks:
 
   - name: "Validate Plugin Version Changes On Skill Version Change"
     run:
-      when: "branch != 'main'"
+      when: "tag !~ '.*' and branch != 'main'"
     task:
       jobs:
         # If any commit on this branch introduces a new skill or changes an
@@ -87,7 +87,7 @@ blocks:
 
   - name: "Tag Plugin Release"
     run:
-      when: "branch = 'main'"
+      when: "tag !~ '.*' and branch = 'main'"
     task:
       jobs:
         # Tags the repo v<plugin-version> (from .claude-plugin/plugin.json) if


### PR DESCRIPTION
## Description

Disable the tag / release job from running on tags, as well as the script to ensure that skill versions bumps prompt plugin version bumps. The latter only works for branches and can safely be disabled on tags. Dummy bumps plugin version for testing.

## Docs

n/a

## Versioning

n/a

## Testing

n/a

## Review

- [x] DTX/DevRel reviewer assigned