### PR TITLE
confluent-skill-creator: fix compatibility visibility, script fallback, description quoting

### DIFF
--- a/skills/confluent-skill-creator/SKILL.md
+++ b/skills/confluent-skill-creator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: confluent-skill-creator
-description: Create Confluent-specific skills for external users. Use this skill when users want to create, build, or author a new skill related to Confluent Cloud, Confluent Platform, Apache Kafka, WarpStream, Flink, Connectors, Schema Registry, Tableflow, CDC pipelines, or any Confluent product. Skills can be use-case focused (like data enrichment, CDC to Tableflow, stream processing workflows) or component-specific (like a Flink skill, Schema Registry skill, or Connector skill). Do NOT use this skill when users want to directly use Confluent products (e.g., build a pipeline, write a producer, deploy Flink SQL) — use the appropriate product-specific skill instead. This skill is specifically for creating new skills, not for using existing ones.
-compatibility: Requires Python 3.9+, confluent-kafka, fastavro, requests. Needs access to a Confluent environment (Cloud, Platform, local Docker, or WarpStream) for E2E testing.
+description: "Create Confluent-specific skills for external users. Use this skill when users want to create, build, or author a new skill related to Confluent Cloud, Confluent Platform, Apache Kafka, WarpStream, Flink, Connectors, Schema Registry, Tableflow, CDC pipelines, or any Confluent product. Skills can be use-case focused (like data enrichment, CDC to Tableflow, stream processing workflows) or component-specific (like a Flink skill, Schema Registry skill, or Connector skill). Do NOT use this skill when users want to directly use Confluent products (e.g., build a pipeline, write a producer, deploy Flink SQL) — use the appropriate product-specific skill instead. This skill is specifically for creating new skills, not for using existing ones."
+compatibility: Requires Python 3.9+, confluent-kafka (with avro/json/protobuf extras), requests, jsonschema, python-dotenv. Needs access to a Confluent environment (Cloud, Platform, local Docker, or WarpStream) for E2E testing.
 metadata:
   author: confluent
   version: "1.1.0"
@@ -20,6 +20,12 @@ This skill extends the base skill-creator workflow with Confluent-specific requi
 - **Credential management**: Proper .env file setup for all required credentials
 - **Spec compliance**: Created skills validated against the [Agent Skills specification](https://agentskills.io/specification)
 - **Smart defaults**: Schema Registry with JSON_SR (schema GUID in header) by default
+
+## Prerequisites
+
+- Python 3.9+
+- `confluent-kafka[avro,json,protobuf]`, `requests`, `jsonschema`, `python-dotenv` Python packages (see `scripts/requirements.txt`)
+- Access to a Confluent environment (Cloud, Platform, local Docker, or WarpStream) for E2E testing
 
 ## When to use this skill
 
@@ -346,7 +352,15 @@ For common operations, use the bundled scripts in `scripts/`:
 - `register_schema.py` — Register schemas with Schema Registry
 - `cleanup_resources.py` — Clean up topics, schemas, Flink statements (local only)
 
-Include relevant scripts in the created skill's `scripts/` directory when packaging.
+**If script execution is denied** (e.g., headless/non-interactive sessions have no approval mechanism) — fall back to the manual steps below rather than stalling silently:
+
+- `check_compute_pool.py` → manually check pool status via the `confluent flink compute-pool` CLI or the Cloud Console
+- `produce_data.py` → manually produce JSON_SR-encoded records via the `confluent kafka topic produce` CLI, or a one-off producer snippet described in prose
+- `consume_and_verify.py` → manually consume via `confluent kafka topic consume` and compare the count/contents against expectations by hand
+- `register_schema.py` → manually register the schema via `confluent schema-registry schema create` or the Schema Registry UI
+- `cleanup_resources.py` → manually delete topics/schemas/statements via their respective `confluent` CLI delete commands (Cloud), or skip cleanup if the environment is ephemeral (local only)
+
+Include relevant scripts in the created skill's `scripts/` directory when packaging — and require the created skill to document this same fallback if it ships its own scripts.
 
 ---
 


### PR DESCRIPTION
## Summary

Three fixes to `skills/confluent-skill-creator/SKILL.md`, sourced from the [Agent Skills Portability Review](https://confluentinc.atlassian.net/wiki/spaces/DTX/pages/5991203400/Agent+Skills+Portability+Review+agentskillimplementation.com+Findings) (agentskillimplementation.com benchmark findings, 2026-08-04). Both "Real gaps" from that review name `confluent-skill-creator` directly.

1. **`compatibility:` field is invisible to the model on Claude Code.** Per the benchmark's Claude Code report, this platform strips YAML frontmatter beyond `name`/`description` before injecting the file into the model — so the skill's own runtime dependencies were never actually surfaced. Added a `## Prerequisites` section to the body.

   While fixing this, found the dependency list itself was stale: the frontmatter said "confluent-kafka, fastavro, requests", but `scripts/requirements.txt` actually lists `confluent-kafka[avro,json,protobuf]`, `requests`, `jsonschema`, `python-dotenv` — no `fastavro` at all. Corrected in both the frontmatter and the new Prerequisites section, and pointed the latter at `requirements.txt` as source of truth so it can't drift silently again.

2. **Bundled scripts have no documented fallback if execution is blocked.** The benchmark's Claude Code test found script execution gets denied by the permission system, with no approval mechanism in headless/non-interactive sessions. `confluent-skill-creator` ships 5 scripts (`check_compute_pool.py`, `produce_data.py`, `consume_and_verify.py`, `register_schema.py`, `cleanup_resources.py`) with no recovery path documented. Added a manual-steps fallback for each, plus a requirement that skills *created by* this skill document the same fallback if they ship their own scripts.

3. **Inconsistent description quoting.** `description:` was unquoted, unlike 3 of the other 8 skills in the repo. Quoted for consistency and to avoid breaking on platforms with stricter YAML parsing (e.g. Antigravity) if a raw colon is ever introduced.

## Out of scope (follow-ups, not fixed here)

- **`CONTRIBUTING.md` scope-precedence documentation** and the **2-platform-vs-broader-portability roadmap decision** — both raised by the same review, but repo-level, not file-level fixes to this skill.
- **`scripts/requirements.txt` lists `python-dotenv`, but no script actually calls `load_dotenv()`** — all 5 scripts read credentials via plain `os.getenv()`, expecting the `.env` file already sourced into the shell. Checked PyPI metadata too: `python-dotenv` isn't pulled in transitively by anything else either. Looks like dead weight, but leaving `requirements.txt` untouched to keep this PR scoped to the portability-review fixes.

## Testing

Docs-only change (SKILL.md body + frontmatter). No script behavior changed.