### PR TITLE
chore: add Claude marketplace plugin manifest validation to build

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "confluent-agent-skills",
+  "description": "Skills for streaming application developers, covering Kafka and Flink client libraries and Schema Registry",
   "owner": {
     "name": "Confluent"
   },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,8 @@
   "name": "streaming-skills-plugin",
   "description": "Skills for streaming application developers, covering Kafka and Flink client libraries and Schema Registry",
   "version": "1.2.1",
+  "author": {
+    "name": "Confluent"
+  },
   "skills": "./skills/"
 }

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -100,7 +100,7 @@ blocks:
   - name: "Validate Claude Plugin Manifest"
     task:
       jobs:
-        - name: "Claude Plugin Validate"
+        - name: "Claude Plugin Validation"
           commands:
             # Install Claude CLI in order to run manifest validation (doesn't call LLM)
             - curl -fsSL https://claude.ai/install.sh | bash

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -96,3 +96,14 @@ blocks:
         - name: "Tag and Release"
           commands:
             - ./tools/tag-and-release.sh
+
+  - name: "Validate Claude Plugin Manifest"
+    task:
+      jobs:
+        - name: "Claude Plugin Validate"
+          commands:
+            # Install Claude CLI in order to run manifest validation (doesn't call LLM)
+            - curl -fsSL https://claude.ai/install.sh | bash
+            # Fails on a non-zero exit AND on a zero exit that still reports
+            # "Found N warnings"
+            - ./tools/check-plugin-manifest.sh

--- a/tools/check-plugin-manifest.sh
+++ b/tools/check-plugin-manifest.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+#
+# check-plugin-manifest.sh — run `claude plugin validate .` and fail the build
+# on either a non-zero exit code or a "Found N warnings" message in the output,
+# since the CLI exits 0 even when it reports warnings.
+#
+# The command's output is always printed, whether it passes or fails.
+#
+# Usage: tools/check-plugin-manifest.sh
+
+set -uo pipefail
+
+output="$(claude plugin validate . 2>&1)"
+status=$?
+
+echo "$output"
+
+if [[ $status -ne 0 ]]; then
+  echo "claude plugin validate . exited with status $status"
+  exit "$status"
+fi
+
+if echo "$output" | grep -qE 'Found [0-9]+ warnings'; then
+  echo "claude plugin validate . reported warnings"
+  exit 1
+fi


### PR DESCRIPTION
## Description

Run Claude plugin manifest validation as part of build, and fix validating warnings.

## Docs

N/A

## Versioning

N/A

## Testing

N/A

## Review

- [x] DTX/DevRel reviewer assigned

## Additional Context

Prompted by [this PR](https://github.com/confluentinc/claude-code-confluent-plugin/pull/25)
